### PR TITLE
Add new petition plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,8 @@ group :development, :test, :staging do
   gem 'spring'
   gem 'rspec'
   gem 'rspec-rails'
+  gem 'rspec-its'
+  gem 'rspec-collection_matchers'
   gem 'pry-rails'
 
   gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -423,11 +423,16 @@ GEM
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
       rspec-mocks (~> 3.4.0)
+    rspec-collection_matchers (1.1.2)
+      rspec-expectations (>= 2.99.0.beta1)
     rspec-core (3.4.1)
       rspec-support (~> 3.4.0)
     rspec-expectations (3.4.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.4.0)
+    rspec-its (1.2.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
     rspec-mocks (3.4.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.4.0)
@@ -580,6 +585,8 @@ DEPENDENCIES
   rails_12factor
   remotipart
   rspec
+  rspec-collection_matchers
+  rspec-its
   rspec-rails
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)

--- a/app/assets/stylesheets/ico-font.css.scss
+++ b/app/assets/stylesheets/ico-font.css.scss
@@ -86,6 +86,9 @@
 .icon-discussion:before {
   content: "\e904";
 }
+.icon-petition:before {
+  content: "\e90e";
+}
 .icon-compilation:before {
   content: "\e905";
 }

--- a/app/helpers/repositories_helper.rb
+++ b/app/helpers/repositories_helper.rb
@@ -1,0 +1,5 @@
+module RepositoriesHelper
+  def plugin_repository
+    @plugin_repository ||= PluginRepository.new
+  end
+end

--- a/app/models/phase.rb
+++ b/app/models/phase.rb
@@ -91,8 +91,11 @@ class Phase < ActiveRecord::Base
     end
 
     def valid_plugin_type
-      unless ["Discussão", "Relatoria"].include? self.plugin_relation.plugin.plugin_type
-        self.plugin_relation.errors.add :plugin, "deve ser do tipo discussão ou relatoria."
+      allowed_types = PluginTypeRepository.new.available_types_with_phases
+      unless allowed_types.include? self.plugin_relation.plugin.plugin_type
+        self.plugin_relation.errors.add :plugin, "deve ser do tipo #{allowed_types.join(', ')}."
+        # Adding errors to the relation, won't halt persistence
+        errors.add :base, "tipo de plugin inválido"
       end
     end
 end

--- a/app/models/plugin.rb
+++ b/app/models/plugin.rb
@@ -20,6 +20,6 @@ class Plugin < ActiveRecord::Base
   validates_presence_of :name, :plugin_type
 
   def self.plugin_types
-    ['Discussão', 'Blog', 'Relatoria', 'Biblioteca', 'Glossário']
+    PluginTypeRepository.new.available_types
   end
 end

--- a/app/repositories/plugin_repository.rb
+++ b/app/repositories/plugin_repository.rb
@@ -1,0 +1,21 @@
+class PluginRepository
+  include Repository
+
+  attr_accessor :plugin_type_repository
+
+  def initialize(plugin_type_repository: PluginTypeRepository.new)
+    @plugin_type_repository = plugin_type_repository
+  end
+
+  def all_with_phases
+    Plugin.where(plugin_type: plugin_type_repository.available_types_with_phases)
+  end
+
+  def all_without_phases
+    Plugin.where(plugin_type: plugin_type_repository.available_types_without_phases)
+  end
+
+  def find_by_name(name)
+    Plugin.find_by_name name
+  end
+end

--- a/app/repositories/plugin_type_repository.rb
+++ b/app/repositories/plugin_type_repository.rb
@@ -1,0 +1,25 @@
+class PluginTypeRepository
+  include Repository
+
+  ALL_TYPES = {
+    discussion: "Discussão",
+    blog: "Blog",
+    report: "Relatoria",
+    biblioteca: "Biblioteca",
+    glossary: "Glossário",
+    petition: "Petição"
+  }.freeze
+
+  def available_types
+    ALL_TYPES.values
+  end
+
+  def available_types_with_phases
+    ALL_TYPES.select { |k| %i(discussion report petition).include? k }.values
+  end
+
+  def available_types_without_phases
+    with_phases = available_types_with_phases
+    ALL_TYPES.reject { |_, v| with_phases.include? v }.values
+  end
+end

--- a/app/repositories/repository.rb
+++ b/app/repositories/repository.rb
@@ -1,0 +1,11 @@
+module Repository
+  extend ActiveSupport::Concern
+
+  def persist(entity)
+    entity.save
+  end
+
+  def persist!(entity)
+    entity.save!
+  end
+end

--- a/app/views/admin/cycles/_form.html.slim
+++ b/app/views/admin/cycles/_form.html.slim
@@ -97,7 +97,7 @@
                         h2 Plugins sem Fase
                   .row
                     .col-xs-12
-                      = f.input :plugins, as: :select, multiple: true, include_blank: 'Selecione os Plugins', label: false, collection: Plugin.where.not(plugin_type: ["Discussão", "Relatoria"])
+                      = f.input :plugins, as: :select, multiple: true, include_blank: 'Selecione os Plugins', label: false, collection: plugin_repository.all_without_phases
       hr
       .text-center
         = f.submit "#{f.object.persisted? ? 'Atualizar' : 'Criar'} Ciclo", class: 'btn'

--- a/app/views/admin/cycles/_phase_fields.html.slim
+++ b/app/views/admin/cycles/_phase_fields.html.slim
@@ -5,7 +5,7 @@
         = f.input :name
         - f.object.plugin_relation ||= PluginRelation.new
         = f.semantic_fields_for :plugin_relation do |p|
-          = p.input :plugin, as: :select, collection: Plugin.where(plugin_type: ["Discussão", "Relatoria"]), input_html: { class: 'select2', disabled: p.object.persisted? }
+          = p.input :plugin, as: :select, collection: plugin_repository.all_with_phases, input_html: { class: 'select2', disabled: p.object.persisted? }
       .col-xs-6
         = f.input :description, as: :text, input_html: { rows: 5 }
     .row

--- a/db/fixtures/plugins.yml
+++ b/db/fixtures/plugins.yml
@@ -1,0 +1,29 @@
+---
+plugins:
+  - name: Blog
+    plugin_type: Blog
+    can_be_readonly: false
+    icon_class: ""
+
+  - name: Discussão
+    plugin_type: Discussão
+    can_be_readonly: false
+    icon_class: discussion
+
+  - name: Relatoria
+    plugin_type: Relatoria
+    can_be_readonly: false
+    icon_class: compilation
+
+  - name: Biblioteca
+    plugin_type: Biblioteca
+    can_be_readonly: false
+
+  - name: Glossário
+    plugin_type: Glossário
+    can_be_readonly: false
+
+  - name: Petição
+    plugin_type: Petição
+    can_be_readonly: false
+    icon_class: petition

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -210,45 +210,13 @@ end
 #   )
 # end
 
-unless plugin_blog = Plugin.find_by_name('Blog')
-  plugin_blog = FactoryGirl.create(:plugin,
-    name:'Blog',
-    plugin_type:'Blog',
-    icon_class: ''
-  )
-end
+Rake::Task["plugins:sync"].execute
 
-unless plugin_discussao = Plugin.find_by_name('Discussão')
-  plugin_discussao = FactoryGirl.create(:plugin,
-    name:'Discussão',
-    plugin_type:'Discussão',
-    icon_class: 'discussion'
-  )
-end
-
-unless plugin_relatoria = Plugin.find_by_name('Relatoria')
-  plugin_relatoria = FactoryGirl.create(:plugin,
-    name:'Relatoria',
-    plugin_type:'Relatoria',
-    icon_class: 'compilation'
-  )
-end
-
-unless plugin_biblioteca = Plugin.find_by_name('Biblioteca')
-  plugin_biblioteca = FactoryGirl.create(:plugin,
-    name: 'Biblioteca',
-    plugin_type: 'Biblioteca',
-    can_be_readonly: false
-  )
-end
-
-unless plugin_glossario = Plugin.find_by_name('Glossário')
-  plugin_glossario = FactoryGirl.create(:plugin,
-    name: 'Glossário',
-    plugin_type: 'Glossário',
-    can_be_readonly: false
-  )
-end
+plugin_blog = Plugin.find_by_name('Blog')
+plugin_discussao = Plugin.find_by_name('Discussão')
+plugin_relatoria = Plugin.find_by_name('Relatoria')
+plugin_biblioteca = Plugin.find_by_name('Biblioteca')
+plugin_glossario = Plugin.find_by_name('Glossário')
 
 # unless plugin_rf = Plugin.find_by_name('Blog Reforma Política')
 #   plugin_rf = FactoryGirl.create(:plugin,

--- a/lib/tasks/plugins.rake
+++ b/lib/tasks/plugins.rake
@@ -1,0 +1,16 @@
+namespace :plugins do
+  desc "Syncs all plugins using the fixture"
+  task sync: :environment do
+    repository = PluginRepository.new
+    fixtures = YAML::load_file(Rails.root.join "db", "fixtures", "plugins.yml").deep_symbolize_keys
+
+    fixtures[:plugins].each do |fixture|
+      plugin = repository.find_by_name(fixture[:name]) || Plugin.new
+      plugin.attributes = fixture
+
+      repository.persist! plugin
+
+      puts "Plugin: #{plugin.name} synced"
+    end
+  end
+end

--- a/spec/helpers/repositories_helper_spec.rb
+++ b/spec/helpers/repositories_helper_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe RepositoriesHelper do
+  describe "#plugin_repository" do
+    subject { helper.plugin_repository }
+
+    it { is_expected.to be_a PluginRepository }
+  end
+end

--- a/spec/models/plugin_spec.rb
+++ b/spec/models/plugin_spec.rb
@@ -29,4 +29,12 @@ RSpec.describe Plugin, type: :model do
       should have_many(attr).dependent(:destroy)
     end
   end
+
+  describe ".plugin_types" do
+    let(:plugin_type_repository) { PluginTypeRepository.new }
+
+    subject { described_class.plugin_types }
+
+    it { is_expected.to eq plugin_type_repository.available_types }
+  end
 end

--- a/spec/repositories/plugin_repository_spec.rb
+++ b/spec/repositories/plugin_repository_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe PluginRepository do
+  let(:repository) { described_class.new }
+
+  its(:plugin_type_repository) { is_expected.to be_a PluginTypeRepository }
+
+  describe "#all_with_phases" do
+    let(:plugin_type_repository) { instance_spy PluginTypeRepository }
+    let!(:plugin_with_phase) { FactoryGirl.create :plugin, plugin_type: "ohmygod" }
+    let!(:plugin_without_phase) { FactoryGirl.create :plugin, plugin_type: "ohnoes" }
+    let(:types_with_phases) { [plugin_with_phase.plugin_type] }
+    let(:types_without_phases) { [plugin_without_phase.plugin_type] }
+
+    before do
+      repository.plugin_type_repository = plugin_type_repository
+
+      allow(plugin_type_repository).to receive(:available_types_with_phases).and_return types_with_phases
+    end
+
+    subject { repository.all_with_phases }
+
+    it do
+      aggregate_failures do
+        is_expected.to have(1).plugin
+        is_expected.to include plugin_with_phase
+      end
+    end
+  end
+
+  describe "#all_without_phases" do
+    let(:plugin_type_repository) { instance_spy PluginTypeRepository }
+    let!(:plugin_with_phase) { FactoryGirl.create :plugin, plugin_type: "ohmygod" }
+    let!(:plugin_without_phase) { FactoryGirl.create :plugin, plugin_type: "ohnoes" }
+    let(:types_with_phases) { [plugin_with_phase.plugin_type] }
+    let(:types_without_phases) { [plugin_without_phase.plugin_type] }
+
+    before do
+      repository.plugin_type_repository = plugin_type_repository
+
+      allow(plugin_type_repository).to receive(:available_types_without_phases).and_return types_without_phases
+    end
+
+    subject { repository.all_without_phases }
+
+    it do
+      aggregate_failures do
+        is_expected.to have(1).plugin
+        is_expected.to include plugin_without_phase
+      end
+    end
+  end
+
+  describe "#find_by_name" do
+    let(:name) { "deadpool" }
+    let!(:plugin) { FactoryGirl.create :plugin, name: name }
+    let!(:another_plugin) { FactoryGirl.create :plugin, name: "yolo" }
+
+    subject { repository.find_by_name name }
+
+    it { is_expected.to eq plugin }
+  end
+end

--- a/spec/repositories/plugin_type_repository_spec.rb
+++ b/spec/repositories/plugin_type_repository_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe PluginTypeRepository do
+  let(:repository) { described_class.new }
+
+  describe "#available_types" do
+    subject { repository.available_types }
+
+    it { is_expected.to have(6).types }
+
+    it { is_expected.to include "Discussão" }
+    it { is_expected.to include "Blog" }
+    it { is_expected.to include "Relatoria" }
+    it { is_expected.to include "Biblioteca" }
+    it { is_expected.to include "Glossário" }
+    it { is_expected.to include "Petição" }
+  end
+
+  describe "#available_types_with_phases" do
+    subject { repository.available_types_with_phases }
+
+    it { is_expected.to have(3).types }
+
+    it { is_expected.to include "Discussão" }
+    it { is_expected.to include "Relatoria" }
+    it { is_expected.to include "Petição" }
+  end
+
+  describe "#available_types_without_phases" do
+    subject { repository.available_types_without_phases }
+
+    it { is_expected.to have(3).types }
+
+    it { is_expected.to include "Blog" }
+    it { is_expected.to include "Biblioteca" }
+    it { is_expected.to include "Glossário" }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,8 @@
 require 'factory_girl'
 require 'shoulda-matchers'
 require 'paperclip/matchers'
+require 'rspec/collection_matchers'
+require 'rspec/its'
 
 RSpec.configure do |config|
   config.after(:suite) do
@@ -50,6 +52,9 @@ RSpec.configure do |config|
     # `true` in RSpec 4.
     mocks.verify_partial_doubles = true
   end
+
+  config.filter_run :focus
+  config.run_all_when_everything_filtered = true
 
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.


### PR DESCRIPTION
This PR closes #25 by introducing a new `petition` plugin.
### How was before?
- there was no way to sync available plugins to the platform
- there was no single point of truth for available plugin (and types)
### What changed?
- persisting new plugins to the platform can now be accomplished by editing the `db/fixtures/plugins.yml`. New plugins will be added, and existing ones synced
- The clean code architecture has been started with `Repositories`. They are responsible for loading data.
- cycles can now contain a phase with the new `petition` plugin
### What should I pay attention when reviewing this PR?

No real concern.
### Is this PR dangerous?

No.
