### PR TITLE
Add admin petition page

### DIFF
--- a/app/controllers/admin/cycles/plugin_relations/petitions_controller.rb
+++ b/app/controllers/admin/cycles/plugin_relations/petitions_controller.rb
@@ -1,0 +1,12 @@
+class Admin::Cycles::PluginRelations::PetitionsController < Admin::ApplicationController
+
+  attr_writer :petition_repository
+
+  def petition_repository
+    @petition_repository ||= PetitionRepository.new
+  end
+
+  def index
+    @petition = petition_repository.mock
+  end
+end

--- a/app/controllers/admin/cycles/plugin_relations_controller.rb
+++ b/app/controllers/admin/cycles/plugin_relations_controller.rb
@@ -13,6 +13,8 @@ class Admin::Cycles::PluginRelationsController < Admin::ApplicationController
       redirect_to [:admin, @cycle, @plugin_relation, :vocabularies]
     when 'Blog'
       redirect_to [:admin, @cycle, :blog_posts]
+    when 'Petição'
+      redirect_to [:admin, @cycle, @plugin_relation, :petitions]
     end
   end
 

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -1,0 +1,2 @@
+class Petition < Struct.new(:body, :document_url)
+end

--- a/app/repositories/petition_repository.rb
+++ b/app/repositories/petition_repository.rb
@@ -1,0 +1,24 @@
+class PetitionRepository
+  include Repository
+
+  def mock
+    Petition.new body_mock, document_url_mock
+  end
+
+  private
+
+  def document_url_mock
+    "https://mudamos-its-production-images.s3.amazonaws.com/uploads/production/compilation_files/1/files/original.pdf"
+  end
+
+  def body_mock
+    <<-BODY.strip_heredoc
+      <div>
+        <h4>Petição X</h4>
+
+        <p>1234567890...</p>
+        <p>Fim</p>
+      </div>
+    BODY
+  end
+end

--- a/app/views/admin/cycles/plugin_relations/petitions/index.html.slim
+++ b/app/views/admin/cycles/plugin_relations/petitions/index.html.slim
@@ -1,0 +1,20 @@
+- breadcrumb :petitions, @cycle, @plugin_relation
+
+.row
+  .col-xs-12
+    .title
+      h2 Petição
+    .row
+      .col-xs-12
+        .card-module
+          .filters.clearfix
+            .pull-right
+              = link_to 'Baixar documento', @petition.document_url, class: 'btn', target: '_blank'
+
+.row
+  .col-xs-12
+    .card-module
+      .title
+        h3 Conteúdo
+
+      div= @petition.body.html_safe

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -3,7 +3,7 @@ crumb :cycles do
 end
 
 crumb :cycle do |c|
-  link c.name, admin_cycles_path(c)
+  link c.name, admin_cycle_path(c)
   parent :cycles
 end
 
@@ -150,6 +150,11 @@ end
 
 crumb :subjects do |c, pr|
   link 'Assuntos', admin_cycle_plugin_relation_subjects_path(c, pr)
+  parent :cycle, c
+end
+
+crumb :petitions do |c, pr|
+  link 'Petição', admin_cycle_plugin_relation_petitions_path(c, pr)
   parent :cycle, c
 end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,7 @@ Rails.application.routes.draw do
         resources :vocabularies, path: 'termos', controller: 'cycles/vocabularies'
         resources :settings, only: [:create, :update], controller: 'cycles/plugin_relations/settings'
         resources :compilation_files, only: [:update], controller: 'cycles/plugin_relations/compilation_files'
+        resources :petitions, only: [:index], controller: 'cycles/plugin_relations/petitions'
       end
       resources :charts, only: [:index], controller: 'cycles/charts', path: 'graficos-personalizados'
     end


### PR DESCRIPTION
This PR closes #30 by adding a new `plugin relation` page for the new plugin `petition`.
### How was before?
- clicking the petition link on the admin sidebar failed because there was no handling of the new plugin
### What changed?
- add a new controller to handle plugin relation when we have petition plugin
- a petition **mock** was added. This can will be later improved with a real petition.
- fixed wrong breadcumb for cycle when it is a parent one
### What should I pay attention when reviewing this PR?

No real concern.
### Is this PR dangerous?

No.
