### PR TITLE
Add 'saiba mais' petition page to the site

### DIFF
--- a/app/assets/javascripts/application.coffee
+++ b/app/assets/javascripts/application.coffee
@@ -49,6 +49,7 @@
 #= require highcharts
 #= require pattern-fill
 #= require reports
+#= require area-toggler
 
 document.expiration_default_time = 300
 

--- a/app/assets/javascripts/area-toggler.js
+++ b/app/assets/javascripts/area-toggler.js
@@ -1,0 +1,31 @@
+(function($) {
+  "use strict";
+
+  $(document).ready(function() {
+    // Hide / show area containers
+    $("body").on("click", ".area-toggler", function(e) {
+      e.preventDefault();
+
+      var $toggler = $(this);
+      var openClass = "area-open";
+      var containerSelector = $toggler.data("container");
+
+      function showContainer() {
+        $(containerSelector).slideDown();
+      }
+
+      function hideContainer() {
+        $(containerSelector).slideUp();
+      }
+
+      if ($toggler.hasClass(openClass)) {
+        $toggler.removeClass(openClass);
+        hideContainer();
+      } else {
+        $toggler.addClass(openClass);
+        showContainer();
+      }
+    });
+  });
+
+})(jQuery);

--- a/app/assets/stylesheets/global.sass
+++ b/app/assets/stylesheets/global.sass
@@ -1447,6 +1447,30 @@ section#static_page
     margin-bottom: 5px
 
 
+#petition-index
+  padding-top: $navbar-height + 90px
+  padding-bottom: 50px
+
+  .call-wrapper
+    margin-top: 40px
+
+  a.download-document
+    color: $gray-dark
+    font-size: 16px
+    text-decoration: none
+
+    .icon-baixeaqui
+      display: inline-block
+      margin-right: 10px
+      transform: rotate(90deg)
+
+  .plip-row
+    margin-top: 30px
+
+    .plip-title
+      font-size: 18px
+
+
 #subjects-index
   background-color: $color-grid-dark-grey
   padding-top: $navbar-height + 90px
@@ -2624,3 +2648,78 @@ nav.navbar.navbar-default ul.dropdown-menu.cycle
       max-width: 700px
       .hover-box
         width: 720px
+
+.call-to-action
+  text-align: center
+  a.main-call
+    border: 5px solid $color-dark-grey
+    font-size: 40px
+    color: $color-dark-grey
+    display: inline-block
+    padding: 25px 15px
+    text-transform: uppercase
+    max-width: 700px
+    height: 180px
+    font-weight: 700
+    overflow: hidden
+    transition: 0.3s all ease
+    cursor: pointer
+    .hover-box
+      width: 720px
+      height: 200px
+      margin-left: -20px
+      transition: 0.3s all ease
+      margin-top: 200px
+    .action-tail
+      position: absolute
+      width: 20px
+      height: 20px
+      border-top: 80px solid #CA3030
+      border-right: 60px solid transparent
+      top: 175px
+      left: 240px
+      z-index: 1
+      &:after
+        content: ""
+        position: absolute
+        width: 20px
+        height: 20px
+        border-top: 64px solid #FFFFFF
+        border-right: 49px solid transparent
+        top: -82px
+        margin-left: 5px
+        z-index: 0
+        transition: 0.05s all ease
+    &:hover
+      a.main-call
+      color: #FFF
+      .hover-box
+        margin-top: -165px
+      .action-tail:after
+        border-top: 0px solid #FFFFFF
+  a.action-icon
+    text-align: left
+    display: block
+    margin: 80px auto 0px
+    width: 550px
+
+  &.plip-sign
+    margin-bottom: 75px
+    a.main-call
+      width: 550px
+      height: 130px
+
+      .action-tail
+        top: 125px
+
+      @media (max-width: $screen-xs-max)
+        width: 320px
+        height: 172px
+
+        .action-tail
+          top: 167px
+          left: 150px
+
+      &:hover
+        .hover-box
+          margin-top: -150px

--- a/app/assets/stylesheets/global.sass
+++ b/app/assets/stylesheets/global.sass
@@ -1464,7 +1464,26 @@ section#static_page
       margin-right: 10px
       transform: rotate(90deg)
 
+  .more-details-row
+    margin-top: 50px
+
+  a.toggle-details
+    background-color: white
+    padding-right: 10px
+
+    &.area-open
+      i
+        transform: rotate(90deg)
+
+    i
+      display: inline-block
+      margin-right: 10px
+
+  hr.toggle-details
+    margin-top: -10px
+
   .plip-row
+    display: none
     margin-top: 30px
 
     .plip-title
@@ -2666,7 +2685,7 @@ nav.navbar.navbar-default ul.dropdown-menu.cycle
     cursor: pointer
     .hover-box
       width: 720px
-      height: 200px
+      height: 300px
       margin-left: -20px
       transition: 0.3s all ease
       margin-top: 200px
@@ -2677,7 +2696,7 @@ nav.navbar.navbar-default ul.dropdown-menu.cycle
       border-top: 80px solid #CA3030
       border-right: 60px solid transparent
       top: 175px
-      left: 240px
+      left: 360px
       z-index: 1
       &:after
         content: ""
@@ -2707,19 +2726,19 @@ nav.navbar.navbar-default ul.dropdown-menu.cycle
     margin-bottom: 75px
     a.main-call
       width: 550px
-      height: 130px
+      height: 170px
 
       .action-tail
-        top: 125px
+        top: 165px
 
       @media (max-width: $screen-xs-max)
         width: 320px
-        height: 172px
+        height: 280px
 
         .action-tail
-          top: 167px
+          top: 275px
           left: 150px
 
       &:hover
         .hover-box
-          margin-top: -150px
+          margin-top: -275px

--- a/app/controllers/cycles/plugin_relations_controller.rb
+++ b/app/controllers/cycles/plugin_relations_controller.rb
@@ -57,9 +57,14 @@ class Cycles::PluginRelationsController < ApplicationController
 
     def set_petition_info
       petition
+      phase
     end
 
     def petition
       @petition ||= petition_repository.mock
+    end
+
+    def phase
+      @phase ||= @plugin_relation.related
     end
 end

--- a/app/controllers/cycles/plugin_relations_controller.rb
+++ b/app/controllers/cycles/plugin_relations_controller.rb
@@ -1,5 +1,11 @@
 class Cycles::PluginRelationsController < ApplicationController
 
+  attr_writer :petition_repository
+
+  def petition_repository
+    @petition_repository ||= PetitionRepository.new
+  end
+
   def show
     @cycle = Cycle.find params[:cycle_id]
     @plugin_relation = @cycle.plugin_relations.find params[:id]
@@ -17,6 +23,9 @@ class Cycles::PluginRelationsController < ApplicationController
           send_csv @cycle.comments.to_public_csv, "comentarios-#{@cycle.slug}"
         }
       end
+    when 'Petição'
+      set_petition_info
+      render 'petition'
     when 'Biblioteca'
       # redirect_to [:admin, @cycle, @plugin_relation, :materials]
     when 'Glossário'
@@ -46,4 +55,11 @@ class Cycles::PluginRelationsController < ApplicationController
       @subjects_users_profile_anonymous_count_in_range = Rails.cache.fetch("#{@cycle.slug}_subjects_users_profile_anonymous_count_in_range")
     end
 
+    def set_petition_info
+      petition
+    end
+
+    def petition
+      @petition ||= petition_repository.mock
+    end
 end

--- a/app/helpers/plugin_helper.rb
+++ b/app/helpers/plugin_helper.rb
@@ -1,0 +1,16 @@
+module PluginHelper
+  def link_to_plugin_page(phase)
+    return unless phase.initial_date < Time.current
+
+    path = case phase.plugin.plugin_type
+    when 'Relatoria', 'Petição'
+      cycle_plugin_relation_path(phase.cycle, phase.plugin_relation)
+    when 'Discussão'
+      [phase.cycle, :subjects]
+    else
+      return
+    end
+
+    link_to 'Saiba mais', path, style: "color: #{phase.cycle.color}"
+  end
+end

--- a/app/views/cycles/plugin_relations/petition.html.slim
+++ b/app/views/cycles/plugin_relations/petition.html.slim
@@ -1,0 +1,28 @@
+- title = "Petição - #{@cycle.title}"
+- image = @cycle.picture(:header)
+
+- meta title: title, og: { title: title, image: image, locale: 'pt_BR', type: 'article' }, twitter: { card: 'summary', title: title, image: { src: image } }
+
+section.container-fluid#petition-index
+  .container
+    .row
+      .col-xs-12
+        h1.section-title style="border-color: #{@cycle.color};" Petição
+    .row
+      .col-xs-12.col-sm-6
+        a.download-document href=@petition.document_url target="_blank"
+          i.icon-baixeaqui style="color: #{@cycle.color};"
+          span Faça o Download da PLIP
+    .row
+      .col-xs-12.call-wrapper
+        .call-to-action.plip-sign
+          a.main-call style="border: 5px solid #{@cycle.color};" href='#'
+            span Assine a PLIP agora
+            span.action-tail style="border-top: 80px solid #{@cycle.color};" &nbsp
+            .hover-box style="background-color: #{@cycle.color};"
+
+    .row.plip-row
+      .col-xs-12
+        h2.section-title.plip-title style="border-color: #{@cycle.color};" PLIP: Projeto de Lei de Iniciativa Popular
+
+        .petition-container= @petition.body.html_safe

--- a/app/views/cycles/plugin_relations/petition.html.slim
+++ b/app/views/cycles/plugin_relations/petition.html.slim
@@ -1,28 +1,38 @@
-- title = "Petição - #{@cycle.title}"
+- title = @phase.description
+- description = @phase.name
 - image = @cycle.picture(:header)
 
-- meta title: title, og: { title: title, image: image, locale: 'pt_BR', type: 'article' }, twitter: { card: 'summary', title: title, image: { src: image } }
+- meta title: title, description: description, og: { title: title, description: description, image: image, locale: 'pt_BR', type: 'article' }, twitter: { description: description, card: 'summary', title: title, image: { src: image } }
 
 section.container-fluid#petition-index
   .container
     .row
       .col-xs-12
-        h1.section-title style="border-color: #{@cycle.color};" Petição
+        h1.section-title style="border-color: #{@cycle.color};"= @phase.description
+    .row
+      .col-xs-12.call-wrapper
+        .call-to-action.plip-sign
+          a.main-call style="border: 5px solid #{@cycle.color};" href='#'
+            span=@phase.name
+            span.action-tail style="border-top: 80px solid #{@cycle.color};" &nbsp
+            .hover-box style="background-color: #{@cycle.color};"
+
     .row
       .col-xs-12.col-sm-6
         a.download-document href=@petition.document_url target="_blank"
           i.icon-baixeaqui style="color: #{@cycle.color};"
           span Faça o Download da PLIP
-    .row
-      .col-xs-12.call-wrapper
-        .call-to-action.plip-sign
-          a.main-call style="border: 5px solid #{@cycle.color};" href='#'
-            span Assine a PLIP agora
-            span.action-tail style="border-top: 80px solid #{@cycle.color};" &nbsp
-            .hover-box style="background-color: #{@cycle.color};"
+
+    .row.more-details-row
+      .col-xs-12
+        a.toggle-details.area-toggler href="#" style="color: #{@cycle.color};" data-container=".plip-row"
+          i class="icon-arrow"
+          | Saiba mais sobre esse projeto
+
+        hr.toggle-details
 
     .row.plip-row
       .col-xs-12
-        h2.section-title.plip-title style="border-color: #{@cycle.color};" PLIP: Projeto de Lei de Iniciativa Popular
+        h2.section-title.plip-title style="border-color: #{@cycle.color};" Detalhes sobre o Projeto de Lei de Iniciativa Popular
 
         .petition-container= @petition.body.html_safe

--- a/app/views/layouts/shared/_phase_description.html.slim
+++ b/app/views/layouts/shared/_phase_description.html.slim
@@ -17,9 +17,4 @@
         h3.phase-plugin-title class=align = phase.name
         p= phase.description.html_safe
     .row.cycle-more
-      .col-xs-12
-        - if phase.plugin.plugin_type == 'Relatoria' and phase.initial_date < Time.zone.now
-          = link_to 'Saiba mais', cycle_plugin_relation_path(@cycle, @cycle.plugin_relations.find('relatoria')), style: "color: #{@cycle.color}"
-        - elsif phase.plugin.plugin_type == 'Discussão' and phase.initial_date < Time.zone.now
-          = link_to 'Saiba mais', [@cycle, :subjects], style: "color: #{@cycle.color}"
-        / = link_to 'Saiba mais', cycle_blog_post_path(@cycle, BlogPost.find_by_slug('como-funciona-o-ciclo-sobre-seguranca-publica')), style: "color: #{@cycle.color}"
+      .col-xs-12= link_to_plugin_page phase

--- a/spec/factories/plugins.rb
+++ b/spec/factories/plugins.rb
@@ -18,6 +18,20 @@ FactoryGirl.define do
     plugin_type "MyString"
     can_be_readonly false
     icon_class 'discussion'
-  end
 
+    trait :report do
+      name "Relatoria"
+      plugin_type "Relatoria"
+    end
+
+    trait :petition do
+      name "Petição"
+      plugin_type "Petição"
+    end
+
+    trait :discussion do
+      name "Discussão"
+      plugin_type "Discussão"
+    end
+  end
 end

--- a/spec/helpers/plugin_helper_spec.rb
+++ b/spec/helpers/plugin_helper_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe PluginHelper do
+  describe "#link_to_plugin_page" do
+    let(:phase) { cycle.phases.first }
+    let(:plugin_relation) { phase.plugin_relation }
+
+    subject { helper.link_to_plugin_page phase }
+
+    context "when report plugin" do
+      let(:cycle) { create_cycle_with_phase phases: [{ plugin_type: :report }] }
+      it { is_expected.to include cycle_plugin_relation_path(cycle, plugin_relation) }
+    end
+
+    context "when petition plugin" do
+      let(:cycle) { create_cycle_with_phase phases: [{ plugin_type: :petition }] }
+      it { is_expected.to include cycle_plugin_relation_path(cycle, plugin_relation) }
+    end
+
+    context "when discussion plugin" do
+      let(:cycle) { create_cycle_with_phase phases: [{ plugin_type: :discussion }] }
+      it { is_expected.to include cycle_subjects_path(cycle) }
+    end
+
+    context "when unknown plugin" do
+      let(:cycle) { create_cycle_with_phase phases: [{ plugin_type: :report }] }
+
+      before { phase.plugin.plugin_type = "unknown" }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when the phase has not started yet" do
+      let(:cycle) { create_cycle_with_phase phases: [{ plugin_type: :report, attrs: { initial_date: 1.day.from_now } }] }
+      it { is_expected.to be_nil }
+    end
+  end
+end

--- a/spec/support/cycle_test_helper.rb
+++ b/spec/support/cycle_test_helper.rb
@@ -1,0 +1,37 @@
+module CycleTestHelper
+  # Creates a cycle with the given phases
+  # @param phases [Array<Hash>] the cycle phases
+  #   @option [Symbol] :plugin_type the plugin type
+  #   @option [Symbol] :attrs custom phase attributes
+  #
+  # @return [Cycle]
+  #
+  # @example Default behaviour
+  #   create_cycle_with_phase #=> cycle # with a report phase
+  #
+  # @example a discussion phase
+  #   create_cycle_with_phase phases: [{ plugin_type: :discussion }]
+  #
+  # @example custom phase attributes
+  #   create_cycle_with_phase phases: [{ plugin_type: :report, attrs: { initial_date: 1.day.from_now }]
+  def create_cycle_with_phase(phases: [{ plugin_type: :report }])
+    cycle = FactoryGirl.build(:cycle)
+
+    phases = phases.map do |phase_attrs|
+      plugin = FactoryGirl.create(:plugin, phase_attrs[:plugin_type])
+      plugin_relation = FactoryGirl.build(:base_plugin_relation, plugin: plugin)
+      phase = FactoryGirl.build(:phase, cycle: cycle, plugin_relation: plugin_relation)
+      phase.attributes = phase_attrs[:attrs] || {}
+
+      plugin_relation.related = phase
+      phase
+    end
+
+    cycle.phases = phases
+    cycle.tap(&:save!)
+  end
+end
+
+RSpec.configure do |config|
+  config.include CycleTestHelper
+end


### PR DESCRIPTION
This PR closes #26 by implementing the new petition page to the site.
### How was before
- there was no way the users could view the petition on the site
- there was business logic on the view file when presenting the 'saiba mais' links
### What changed?
- new petition page was added, which displays the petition **mock**
- refactored the 'saiba mais' links into a view helper, which is now properly tested
### What should I pay attention when reviewing this PR?

Is the the new page good enough? It will change later with social sharing by the way.

![mobile](https://dl.dropboxusercontent.com/u/732139/trash/Screenshot%202016-11-01%2011.39.55.png)

![desktop](https://dl.dropboxusercontent.com/u/732139/trash/Nov-01-2016%2011-36-30.gif)
### Is this PR dangerous?

No.
