### PR TITLE
Add social sharing to the petition page

### DIFF
--- a/app/assets/stylesheets/global.sass
+++ b/app/assets/stylesheets/global.sass
@@ -1489,6 +1489,9 @@ section#static_page
     .plip-title
       font-size: 18px
 
+  @media (max-width: $screen-sm-min)
+    .share-col
+      margin-top: 15px
 
 #subjects-index
   background-color: $color-grid-dark-grey
@@ -2737,8 +2740,14 @@ nav.navbar.navbar-default ul.dropdown-menu.cycle
 
         .action-tail
           top: 275px
-          left: 150px
+          left: 30%
 
       &:hover
         .hover-box
           margin-top: -275px
+
+.fb-share-button, .twitter-share-button
+  vertical-align: top
+
+.medium-gap
+  margin-top: 50px

--- a/app/views/cycles/plugin_relations/petition.html.slim
+++ b/app/views/cycles/plugin_relations/petition.html.slim
@@ -17,8 +17,12 @@ section.container-fluid#petition-index
             span.action-tail style="border-top: 80px solid #{@cycle.color};" &nbsp
             .hover-box style="background-color: #{@cycle.color};"
 
-    .row
-      .col-xs-12.col-sm-6
+    .row.medium-gap
+      .col-xs-12.col-sm-2.share-col
+        div class="fb-share-button" data-layout="button_count" data-size="small" data-mobile-iframe="false"
+      .col-xs-12.col-sm-2.share-col
+        a href="https://twitter.com/share" class="twitter-share-button" data-size="small" data-lang="pt" data-show-count="true"
+      .col-xs-12.col-sm-4.share-col
         a.download-document href=@petition.document_url target="_blank"
           i.icon-baixeaqui style="color: #{@cycle.color};"
           span Faça o Download da PLIP

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -17,7 +17,8 @@ html
 
     #fb-root
     = render 'outsiders/facebook_initializer'
-    
+    = render 'outsiders/twitter'
+
     - flash.each do |name, msg|
       - if msg.respond_to? :html_safe
         javascript:
@@ -26,7 +27,7 @@ html
     - if Rails.env.production?
       = render 'outsiders/analytics'
       = render 'outsiders/facebook_pixel'
-      
+
       - if session.delete(:new_user_created)
         javascript:
           fbq('track', 'CompleteRegistration');

--- a/app/views/outsiders/_twitter.html.erb
+++ b/app/views/outsiders/_twitter.html.erb
@@ -1,0 +1,1 @@
+<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


### PR DESCRIPTION
This PR closes #32 by adding social media share buttons to the petition page.

### How was it before?

- there was no social media share buttons

### What changed?

- facebook and twitter share buttons were added to the petition page

### What should I pay attention when reviewing this PR?

- are the buttons positions good enough?

### Is this PR dangerous?

No.

![screenshot 2016-11-01 17 24 04](https://cloud.githubusercontent.com/assets/252061/19904150/a2245756-a058-11e6-873f-3b17cbc8d5ef.png)

![screenshot 2016-11-01 17 23 38](https://cloud.githubusercontent.com/assets/252061/19904159/a8b76a18-a058-11e6-99d2-c67b73d5a469.png)
