### PR TITLE
Add mocked PLIP id to the entity response.

### DIFF
--- a/app/controllers/api/v2/entities/plip.rb
+++ b/app/controllers/api/v2/entities/plip.rb
@@ -6,12 +6,17 @@ module Api
 
         root 'plips', 'plip'
 
+        expose :id
         expose :document_url
         expose :content
         expose :cycle, using: Api::V2::Entities::Cycle
         expose :phase, using: Api::V2::Entities::Phase
 
         swagger_schema :'Api::V2::Entities::Plip' do
+          property :id do
+            key :type, :integer
+          end
+
           property :document_url do
             key :type, :string
             format "url"

--- a/app/models/plip.rb
+++ b/app/models/plip.rb
@@ -24,4 +24,10 @@ class Plip
   def cycle
     phase.cycle
   end
+
+  # Mocked plip id.
+  # This represents the plip version
+  def id
+    1
+  end
 end

--- a/spec/support/shared_examples/api/a_plip_response.rb
+++ b/spec/support/shared_examples/api/a_plip_response.rb
@@ -3,6 +3,7 @@
 #   let(:phase) { "a phase" }
 #   subject(:plip_response) { {} }
 RSpec.shared_examples_for "a plip response" do
+  its([:id]) { is_expected.to be_present }
   its([:document_url]) { is_expected.to be_present }
   its([:content]) { is_expected.to be_present }
 


### PR DESCRIPTION
This PR closes #45 by mocking a PLIP id on the `plips` api.

### How was it before?

- there was no id. No way to uniquely identify the plip

### What changed?

- The `plips` api response now includes a mocked plip id that will be used to version the plip.

### What should I pay attention when reviewing this PR?

It is important to note that both `phase#id` and `plip#id` will be used to identify the plip.

`phase#id` will be the considered the *main* id, identifying a plip's parent object, while the `plip#id` will actually be the version (which contains the given html code e document url).

### Is this PR dangerous?

No.

