### PR TITLE
Export user data to a json format.

### DIFF
--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -44,4 +44,24 @@ namespace :users do
       AdminUser.find_by_email(e).update_column(:admin_type, 1)
     end
   end
+
+  desc "Exports user data -- output_path defaults to STDOUT"
+  task :export, [:output_path] => :environment do |_, args|
+    output = args[:output_path] && File.new(args[:output_path], "w") || STDOUT
+
+    users = -> do
+      User.find_each(batch_size: 500).map do |user|
+        {
+          password: user.encrypted_password,
+          name: user.name,
+          cpf: user.cpf,
+          email: user.email
+        }
+      end
+    end
+
+    IO.open(output.fileno, "w") do |f|
+      f.write users.call.to_json
+    end
+  end
 end


### PR DESCRIPTION
This PR closes #29 by adding a new rake task which dumps users to a json format.

### How was it before?

- there was no way to export some user data

### What changed?

- `rake users:export` was added which when invoked, dumps the users json to the **stdout**. Optionally pass a file path which will be written ie. `rake users:export["/tmp/users.json"]`

### What should I pay attention when reviewing this PR?

- Should we include more information?

### Is this PR dangerous?

NO.