### PR TITLE
Removing https from the hardcoded links to plataformabrasil.org.br

### DIFF
--- a/app/views/cycles/index.html.slim
+++ b/app/views/cycles/index.html.slim
@@ -75,7 +75,7 @@ section.container-fluid#cycles
       - @cycles.each do |c|
         = render 'widgets/home_cycle', image: c.picture(:thumb), name: c.name, url: cycle_path(c), color: c.color, text: c.finished? ? 'Veja como foi' : 'Participe'
 
-      = render 'widgets/home_cycle', image: image_path('placeholder_home2.jpg'), name: 'Reforma Política do Século 21', url: 'https://plataformabrasil.org.br/', color: 'rgb(184,202,0)', text: 'Veja como foi', target: '_blank'
+      = render 'widgets/home_cycle', image: image_path('placeholder_home2.jpg'), name: 'Reforma Política do Século 21', url: 'http://plataformabrasil.org.br/', color: 'rgb(184,202,0)', text: 'Veja como foi', target: '_blank'
 
 
 = javascript_include_tag 'navbar-sticky'

--- a/app/views/layouts/shared/_base_header.html.slim
+++ b/app/views/layouts/shared/_base_header.html.slim
@@ -33,7 +33,7 @@
             ul.dropdown-menu
               - @cycles.each do |c|
                 li= link_to c.title, c
-              li= link_to 'Reforma Política do Século 21', 'https://plataformabrasil.org.br/', target: '_blank'
+              li= link_to 'Reforma Política do Século 21', 'http://plataformabrasil.org.br/', target: '_blank'
           li= link_to 'BLOG', blog_posts_path
     = render 'layouts/search_bar'
 


### PR DESCRIPTION
This PR closes #62 by removing `https` from the links

### How was it before?

- the links to plataformabrasil.org.br had the `https` prefix

### What has changed?

- the links were changed to use the `http` prefix

### What should I pay attention when reviewing this PR?

nothing special

### Is this PR dangerous?

No.