### PR TITLE
Removing the link from the lead text from the home page

### DIFF
--- a/app/views/cycles/index.html.slim
+++ b/app/views/cycles/index.html.slim
@@ -15,7 +15,7 @@ section.container-fluid#hero
     .row
       .col-xs-12.col-md-10
         h2 style="color: #fff;"
-          a{href="https://mudamos-its-production-images.s3.amazonaws.com/uploads/production/compilation_files/1/files/original.pdf?1472596045" style="color: #fff"} =Setting.find_by_key('home_sub_title').value
+          =Setting.find_by_key('home_sub_title').value
 
 section.container-fluid#about
   .full-background-image.parallax-window data-parallax="scroll" data-image-src=image


### PR DESCRIPTION
This PR closes #61 by removing the link from the lead text on the home

### How was it before?

- the lead text on the home page had a hardcoded link

### What has changed?

- this link is gone now and only the text is show

### What should I pay attention when reviewing this PR?

nothing special

### Is this PR dangerous?

No.