### PR TITLE
Adding missing fields to the plips api

### DIFF
--- a/app/controllers/api/v2/entities/plip.rb
+++ b/app/controllers/api/v2/entities/plip.rb
@@ -9,6 +9,9 @@ module Api
         expose :id
         expose :document_url
         expose :content
+        expose :presentation
+        expose :signatures_required
+        expose :call_to_action
         expose :cycle, using: Api::V2::Entities::Cycle
         expose :phase, using: Api::V2::Entities::Phase
 
@@ -23,6 +26,18 @@ module Api
           end
 
           property :content do
+            key :type, :string
+          end
+
+          property :presentation do
+            key :type, :string
+          end
+
+          property :signatures_required do
+            key :type, :string
+          end
+
+          property :call_to_action do
             key :type, :string
           end
 

--- a/app/models/plip.rb
+++ b/app/models/plip.rb
@@ -11,13 +11,28 @@ class Plip
   #   @return [Phase]
   attr_accessor :phase
 
+  # @!attribute [rw] presentation
+  #   @return [String]
+  attr_accessor :presentation
+ 
+  # @!attribute [rw] signatures_required
+  #   @return [String]
+  attr_accessor :signatures_required
+ 
+  # @!attribute [rw] call_to_action
+  #   @return [String]
+  attr_accessor :call_to_action
+
   # @param document_url [String]
   # @param content [String]
   # @param phase [Phase]
-  def initialize(document_url:, content:, phase:)
+  def initialize(document_url:, content:, phase:, presentation:, signatures_required:, call_to_action:)
     @document_url = document_url
     @content = content
     @phase = phase
+    @presentation = presentation
+    @signatures_required = signatures_required
+    @call_to_action = call_to_action
   end
 
   # @return [Cycle]

--- a/app/repositories/plip_repository.rb
+++ b/app/repositories/plip_repository.rb
@@ -20,7 +20,10 @@ class PlipRepository
 
       Plip.new document_url: petition.document_url,
                content: petition.body,
-               phase: phase
+               phase: phase,
+               presentation: petition.presentation,
+               signatures_required: petition.signatures_required,
+               call_to_action: petition.call_to_action
     end
 
     Pagination.new items: plips, page: page, limit: limit, has_next: has_next


### PR DESCRIPTION
This PR closes #83

### How was it before?

- the plips api did not had the fields: `presentation`, `signatures_required` and `call_to_action`

### What has changed?

- the missing fields were added

### What should I pay attention when reviewing this PR?

Nothing special

### Is this PR dangerous?

No.
