### PR TITLE
Petition automatic pdf upload (Issue 81)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,11 @@ gem "select2-rails"
 # gem 'capistrano-rails', group: :development
 
 gem 'simplemde-rails'
+gem 'prawn'
+gem 'prawn-table'
+gem 'kramdown'
+gem 'shoryuken'
+gem 'aws-sdk', '~> 2'
 
 group :development, :test, :staging do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile
+++ b/Gemfile
@@ -92,6 +92,7 @@ group :development, :test, :staging do
   gem 'rspec-its'
   gem 'rspec-collection_matchers'
   gem 'pry-rails'
+  gem 'pry-nav'
 
   gem 'dotenv-rails'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,14 @@ GEM
       json
     awesome_nested_set (3.0.2)
       activerecord (>= 4.0.0, < 5)
+    aws-sdk (2.6.44)
+      aws-sdk-resources (= 2.6.44)
+    aws-sdk-core (2.6.44)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.6.44)
+      aws-sdk-core (= 2.6.44)
+    aws-sigv4 (1.0.0)
     bcrypt (3.1.10)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
@@ -73,6 +81,23 @@ GEM
     bullet (4.14.10)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.9.0)
+    celluloid (0.17.3)
+      celluloid-essentials
+      celluloid-extras
+      celluloid-fsm
+      celluloid-pool
+      celluloid-supervision
+      timers (>= 4.1.1)
+    celluloid-essentials (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-extras (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-fsm (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-pool (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-supervision (0.20.6)
+      timers (>= 4.1.1)
     climate_control (0.0.3)
       activesupport (>= 3.0)
     cocaine (0.5.8)
@@ -268,6 +293,7 @@ GEM
     gretel (3.0.8)
       rails (>= 3.2.0)
     hashie (3.4.3)
+    hitimes (1.2.4)
     http (0.9.8)
       addressable (~> 2.3)
       http-cookie (~> 1.0)
@@ -286,6 +312,7 @@ GEM
     jbuilder (2.3.2)
       activesupport (>= 3.0.0, < 5)
       multi_json (~> 1.2)
+    jmespath (1.3.1)
     jquery-rails (4.0.5)
       rails-dom-testing (~> 1.0)
       railties (>= 4.2.0)
@@ -302,6 +329,7 @@ GEM
       addressable
       faraday
       multi_json
+    kramdown (1.13.2)
     launchy (2.4.3)
       addressable (~> 2.3)
     less (2.6.0)
@@ -373,6 +401,7 @@ GEM
       mimemagic (= 0.3.0)
     paranoia (2.1.4)
       activerecord (~> 4.0)
+    pdf-core (0.6.1)
     pg (0.18.4)
     pg_search (1.0.5)
       activerecord (>= 3.1)
@@ -380,6 +409,11 @@ GEM
       arel
     polyamorous (1.1.0)
       activerecord (>= 3.0)
+    prawn (2.1.0)
+      pdf-core (~> 0.6.1)
+      ttfunk (~> 1.4.0)
+    prawn-table (0.2.2)
+      prawn (>= 1.3.0, < 3.0.0)
     pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -465,6 +499,9 @@ GEM
       rdoc (~> 4.0)
     select2-rails (4.0.0)
       thor (~> 0.14)
+    shoryuken (2.1.2)
+      aws-sdk-core (~> 2)
+      celluloid (~> 0.16)
     shoulda-callback-matchers (1.1.3)
       activesupport (>= 3)
     shoulda-matchers (3.0.1)
@@ -508,8 +545,11 @@ GEM
     thread_safe (0.3.5)
     tilt (2.0.1)
     timecop (0.8.0)
+    timers (4.1.2)
+      hitimes
     tinymce-rails (4.3.1)
       railties (>= 3.1.1)
+    ttfunk (1.4.0)
     twitter (5.15.0)
       addressable (~> 2.3)
       buftok (~> 0.2.0)
@@ -553,6 +593,7 @@ DEPENDENCIES
   annotate
   attr_encrypted
   awesome_nested_set
+  aws-sdk (~> 2)
   better_errors
   bootstrap-sass
   bourbon
@@ -580,6 +621,7 @@ DEPENDENCIES
   js-routes
   kaminari
   koala
+  kramdown
   less-rails
   libv8
   metamagic
@@ -592,6 +634,8 @@ DEPENDENCIES
   paranoia
   pg
   pg_search
+  prawn
+  prawn-table
   pry-rails
   rack-cors
   rails (= 4.2.3)
@@ -605,6 +649,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   select2-rails
+  shoryuken
   shoulda-callback-matchers
   shoulda-matchers
   simplemde-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -418,6 +418,8 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry-nav (0.2.4)
+      pry (>= 0.9.10, < 0.11.0)
     pry-rails (0.3.4)
       pry (>= 0.9.10)
     rack (1.6.4)
@@ -636,6 +638,7 @@ DEPENDENCIES
   pg_search
   prawn
   prawn-table
+  pry-nav
   pry-rails
   rack-cors
   rails (= 4.2.3)

--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ Follow the instructions, and use the created user to access the admin area.
   - 'AWS_SECRET_ACCESS_KEY': AWS secret access key used to access the aws resources
   - 'AWS_REGION': The region where the AWS resources are
 
+### Queue configurations
+
+## Petition pdf generation
+
+Recommended values:
+ * Default Visibility Timeout: 60 secs
+ * Message Retention Period: 4 days (SQS default)
+ * Maximum Message Size: 256 KB (SQS default)
+ * Delivery Delay: 0 secs (SQS default)
+ * Receive Message Wait Time: 0 secs (SQS default)
+
 ### Running the workers
 
 `bundle exec shoryuken -C config/shoryuken.yml -R`

--- a/README.md
+++ b/README.md
@@ -29,3 +29,16 @@ Follow the instructions, and use the created user to access the admin area.
  1 - Run `gem install mailcatcher`
  2 - Run `mailcatcher`
  3 - Go to `http://localhost:1080/`
+
+### Environment variables
+        
+  - 'PETITION_PDF_GENERATION_QUEUE': Name of the sqs queue used for the generation of the PDFs of the petitions
+  - 'PETITION_PDF_GENERATION_QUEUE_PRIORITY': The priority of the sqs queue for the generation of the PDFs of the petitions
+  - 'PETITION_PDF_BUCKET': Name of the bucket where the petition's pdfs are stored
+  - 'AWS_ACCESS_KEY_ID': AWS access key id used to access the aws resources
+  - 'AWS_SECRET_ACCESS_KEY': AWS secret access key used to access the aws resources
+  - 'AWS_REGION': The region where the AWS resources are
+
+### Running the workers
+
+`bundle exec shoryuken -C config/shoryuken.yml -R`

--- a/app/controllers/admin/cycles/plugin_relations/petitions_controller.rb
+++ b/app/controllers/admin/cycles/plugin_relations/petitions_controller.rb
@@ -60,8 +60,7 @@ class Admin::Cycles::PluginRelations::PetitionsController < Admin::ApplicationCo
   end
 
   def petition_versionable_params
-    params.require(:petition_plugin_detail).require(:current_version)
-      .permit(:document_url, :body)
+    params.require(:petition_plugin_detail).require(:current_version).permit(:body)
   end
 
   def enqueue_pdf_generation

--- a/app/controllers/admin/cycles/plugin_relations/petitions_controller.rb
+++ b/app/controllers/admin/cycles/plugin_relations/petitions_controller.rb
@@ -66,6 +66,6 @@ class Admin::Cycles::PluginRelations::PetitionsController < Admin::ApplicationCo
 
   def enqueue_pdf_generation
     version = @petition.petition_detail_versions.where(published: false).first
-    PetitionPdfGenerationWorker.perform_async id: version.id
+    PetitionPdfGenerationWorker.perform_async id: version.id if version
   end
 end

--- a/app/controllers/admin/cycles/plugin_relations/petitions_controller.rb
+++ b/app/controllers/admin/cycles/plugin_relations/petitions_controller.rb
@@ -14,7 +14,7 @@ class Admin::Cycles::PluginRelations::PetitionsController < Admin::ApplicationCo
   def update
     @petition = @plugin_relation.petition_detail
 
-    if detail_updater.perform @petition, petition_params, petition_versionable_params
+    if detail_updater.perform @petition, petition_params, petition_body
       enqueue_pdf_generation
       flash[:success] = "Petição salva com sucesso."
       redirect_to [:admin, @cycle, @plugin_relation, :petitions]
@@ -32,7 +32,7 @@ class Admin::Cycles::PluginRelations::PetitionsController < Admin::ApplicationCo
 
     @petition = PetitionPlugin::Detail.new(plugin_relation_id: @plugin_relation.id)
 
-    if detail_updater.perform @petition, petition_params, petition_versionable_params
+    if detail_updater.perform @petition, petition_params, petition_body
       enqueue_pdf_generation
       flash[:success] = "Petição salva com sucesso."
       redirect_to [:admin, @cycle, @plugin_relation, :petitions]
@@ -49,8 +49,8 @@ class Admin::Cycles::PluginRelations::PetitionsController < Admin::ApplicationCo
       .permit(:call_to_action, :signatures_required, :presentation)
   end
 
-  def petition_versionable_params
-    params.require(:petition_plugin_detail).require(:current_version).permit(:body)
+  def petition_body 
+    params.require(:petition_plugin_detail).require(:current_version).permit(:body)[:body]
   end
 
   def enqueue_pdf_generation

--- a/app/jobs/petition_pdf_generation_worker.rb
+++ b/app/jobs/petition_pdf_generation_worker.rb
@@ -1,0 +1,21 @@
+class PetitionPdfGenerationWorker
+  include Shoryuken::Worker
+  shoryuken_options queue: Rails.application.secrets.queues['petition_pdf_generation']
+
+  def perform(sqs_msg, body)
+    petition_detail_version_id = JSON.parse(body)['id']
+
+
+    puts petition_detail_version_id
+
+    petition_detail_version = PetitionPlugin::DetailVersion.find petition_detail_version_id
+    pdf = Kramdown::Document.new(petition_detail_version.body).to_pdf
+
+    s3 = Aws::S3::Resource.new
+    obj = s3.bucket(Rails.application.secrets.buckets['petition_pdf']).object("#{petition_detail_version_id}.pdf")
+    metadata = obj.put(body: pdf)
+
+    document_url = "teste"#metadata.url
+    petition_detail_version.update published: true, document_url: document_url
+  end
+end

--- a/app/jobs/petition_pdf_generation_worker.rb
+++ b/app/jobs/petition_pdf_generation_worker.rb
@@ -10,7 +10,7 @@ class PetitionPdfGenerationWorker
 
   def perform(sqs_msg, body)
     petition_detail_version_id = JSON.parse(body)['id']
-    puts "Processing plugin detail version: #{petition_detail_version_id}"
+    Rails.logger.info "Processing plugin detail version: #{petition_detail_version_id}"
 
     version = PetitionPlugin::DetailVersion.find petition_detail_version_id
 

--- a/app/jobs/petition_pdf_generation_worker.rb
+++ b/app/jobs/petition_pdf_generation_worker.rb
@@ -3,16 +3,18 @@ class PetitionPdfGenerationWorker
   shoryuken_options queue: Rails.application.secrets.queues['petition_pdf_generation'], auto_delete: true
 
   attr_reader :petition_pdf_service
+  attr_reader :repository
 
-  def initialize(petition_pdf_service: PetitionPdfService.new)
+  def initialize(petition_pdf_service: PetitionPdfService.new, repository: PetitionPlugin::DetailVersionRepository.new)
     @petition_pdf_service = petition_pdf_service
+    @repository = repository
   end
 
   def perform(sqs_msg, body)
     petition_detail_version_id = JSON.parse(body)['id']
     Rails.logger.info "Processing plugin detail version: #{petition_detail_version_id}"
 
-    version = PetitionPlugin::DetailVersion.find petition_detail_version_id
+    version = repository.find_by_id! petition_detail_version_id
 
     document_url = petition_pdf_service.generate(version) 
     version.update published: true, document_url: document_url

--- a/app/models/petition_plugin/detail.rb
+++ b/app/models/petition_plugin/detail.rb
@@ -27,6 +27,10 @@ class PetitionPlugin::Detail < ActiveRecord::Base
   validate :plugin_type_petition
 
   def current_version
+    petition_detail_versions.last
+  end
+
+  def published_version
     petition_detail_versions.where(published: true).last
   end
 end

--- a/app/models/petition_plugin/detail.rb
+++ b/app/models/petition_plugin/detail.rb
@@ -27,6 +27,6 @@ class PetitionPlugin::Detail < ActiveRecord::Base
   validate :plugin_type_petition
 
   def current_version
-    petition_detail_versions.last
+    petition_detail_versions.where(published: true).last
   end
 end

--- a/app/models/petition_plugin/detail_version.rb
+++ b/app/models/petition_plugin/detail_version.rb
@@ -16,6 +16,5 @@ class PetitionPlugin::DetailVersion < ActiveRecord::Base
 
   belongs_to :petition_plugin_detail
 
-  validates :document_url, presence: true
   validates :body, presence: true
 end

--- a/app/models/petition_plugin/detail_version.rb
+++ b/app/models/petition_plugin/detail_version.rb
@@ -14,7 +14,7 @@
 class PetitionPlugin::DetailVersion < ActiveRecord::Base
   acts_as_paranoid
 
-  belongs_to :petition_plugin_detail
+  belongs_to :petition_plugin_detail, class_name: 'PetitionPlugin::Detail'
 
   validates :body, presence: true
 end

--- a/app/models/phase.rb
+++ b/app/models/phase.rb
@@ -58,11 +58,11 @@ class Phase < ActiveRecord::Base
   end
 
   def in_progress?
-    (self.initial_date <= Time.zone.now) and (self.final_date >= Time.zone.now)
+    ((self.initial_date <= Time.zone.now) and (self.final_date >= Time.zone.now)) && self.plugin_relation.ready?
   end
 
   def shortly?
-    self.initial_date > Time.zone.now
+    self.initial_date > Time.zone.now || !self.plugin_relation.ready?
   end
 
   def self.statuses

--- a/app/models/plugin_relation.rb
+++ b/app/models/plugin_relation.rb
@@ -54,6 +54,14 @@ class PluginRelation < ActiveRecord::Base
 
   after_create :create_compilation_file, if: -> { self.plugin.present? and self.plugin.plugin_type == 'Relatoria' }
 
+  def ready?
+    if plugin.plugin_type == 'Petição'
+      petition_detail.present? && petition_detail.published_version.present?
+    else
+      true
+    end
+  end
+
   private
 
     def create_compilation_file

--- a/app/repositories/petition_plugin/detail_version_repository.rb
+++ b/app/repositories/petition_plugin/detail_version_repository.rb
@@ -1,0 +1,5 @@
+module PetitionPlugin
+  class DetailVersionRepository
+    include Repository
+  end
+end

--- a/app/repositories/plip_repository.rb
+++ b/app/repositories/plip_repository.rb
@@ -13,6 +13,7 @@ class PlipRepository
       .where(plugin_relation: { plugin: { plugin_type: PluginTypeRepository::ALL_TYPES[:petition] }})
       .where.not(petition_plugin_details: { id: nil })
       .where.not(petition_plugin_detail_versions: { id: nil })
+      .where(petition_plugin_detail_versions: { published: true })
       .page(page)
       .per(limit)
 
@@ -22,8 +23,8 @@ class PlipRepository
       petition = phase.plugin_relation.petition_detail
 
       Plip.new id: petition.current_version.id,
-               document_url: petition.current_version.document_url,
-               content: petition.current_version.body,
+               document_url: petition.published_version.document_url,
+               content: petition.published_version.body,
                phase: phase,
                presentation: petition.presentation,
                signatures_required: petition.signatures_required,

--- a/app/repositories/plip_repository.rb
+++ b/app/repositories/plip_repository.rb
@@ -22,7 +22,7 @@ class PlipRepository
     plips = phases.map do |phase|
       petition = phase.plugin_relation.petition_detail
 
-      Plip.new id: petition.current_version.id,
+      Plip.new id: petition.published_version.id,
                document_url: petition.published_version.document_url,
                content: petition.published_version.body,
                phase: phase,

--- a/app/services/petition_pdf_service.rb
+++ b/app/services/petition_pdf_service.rb
@@ -5,7 +5,7 @@ class PetitionPdfService
     cycle = version.petition_plugin_detail.plugin_relation.related.cycle
     phase = version.petition_plugin_detail.plugin_relation.related
 
-    document_name = "#{cycle.subdomain}-peticao-#{phase.id}-#{version.id}.pdf"
+    document_name = "#{cycle.slug}-peticao-#{phase.id}-#{version.id}.pdf"
 
     s3 = Aws::S3::Resource.new
     obj = s3.bucket(Rails.application.secrets.buckets['petition_pdf']).object(document_name)

--- a/app/services/petition_pdf_service.rb
+++ b/app/services/petition_pdf_service.rb
@@ -1,0 +1,16 @@
+class PetitionPdfService
+  def generate(version)
+    pdf = Kramdown::Document.new(version.body).to_pdf
+
+    cycle = version.petition_plugin_detail.plugin_relation.related.cycle
+    phase = version.petition_plugin_detail.plugin_relation.related
+
+    document_name = "#{cycle.subdomain}-peticao-#{phase.id}-#{version.id}.pdf"
+
+    s3 = Aws::S3::Resource.new
+    obj = s3.bucket(Rails.application.secrets.buckets['petition_pdf']).object(document_name)
+    obj.put(body: pdf, acl: 'public-read')
+
+    obj.public_url
+  end
+end

--- a/app/use_cases/petition_plugin/detail_updater.rb
+++ b/app/use_cases/petition_plugin/detail_updater.rb
@@ -1,11 +1,11 @@
 module PetitionPlugin
   class DetailUpdater
-    def perform(detail, attrs, version_attrs)
+    def perform(detail, attrs, detail_body)
       detail.update_attributes attrs 
 
       current_version = detail.current_version
-      if current_version.nil? || current_version.body != version_attrs[:body]
-        detail.petition_detail_versions << PetitionPlugin::DetailVersion.new(version_attrs)
+      if current_version.nil? || current_version.body != detail_body
+        detail.petition_detail_versions << PetitionPlugin::DetailVersion.new(body: detail_body)
       end
 
       detail.save

--- a/app/use_cases/petition_plugin/detail_updater.rb
+++ b/app/use_cases/petition_plugin/detail_updater.rb
@@ -1,14 +1,23 @@
 module PetitionPlugin
+
+  Response = Struct.new(:success, :detail, :version)
+
   class DetailUpdater
     def perform(detail, attrs, detail_body)
+      response = Response.new
+
       detail.update_attributes attrs 
 
       current_version = detail.current_version
       if current_version.nil? || current_version.body != detail_body
-        detail.petition_detail_versions << PetitionPlugin::DetailVersion.new(body: detail_body)
+        response.version = PetitionPlugin::DetailVersion.new(body: detail_body)
+        detail.petition_detail_versions << response.version
       end
 
-      detail.save
+      response.success = detail.save
+      response.detail = detail
+
+      response
     end
   end
 end

--- a/app/views/admin/cycles/plugin_relations/petitions/_form.html.slim
+++ b/app/views/admin/cycles/plugin_relations/petitions/_form.html.slim
@@ -10,9 +10,6 @@
   = f.fields_for :current_version, @petition.current_version do |version_form|
     .row
       .col-xs-12
-        = version_form.input :document_url, as: :url, label: 'URL do documento'
-    .row
-      .col-xs-12
         = version_form.input :body, as: :text, label: 'Texto completo', input_html: { class: 'markdown-input' }
   .row
     .col-xs-12

--- a/app/views/admin/cycles/plugin_relations/petitions/index.html.slim
+++ b/app/views/admin/cycles/plugin_relations/petitions/index.html.slim
@@ -39,8 +39,11 @@
          h3 Texto completo 
        .filters.clearfix
          .pull-right
-           = link_to 'Baixar documento', @petition.current_version.document_url, class: 'btn', target: '_blank' if @petition.current_version.document_url if @petition.current_version && @petition.current_version.published
-       - if @petition.current_version && @petition.current_version.published && @petition.current_version.body
+           - if @petition.published_version
+             = link_to 'Baixar documento', @petition.published_version.document_url, class: 'btn', target: '_blank'
+           - else
+             = 'Nenhuma versão publicada ainda'
+       - if @petition.current_version
          .plip-body= markdown @petition.current_version.body
 - else
   = 'Petição em branco, edite para adicionar conteúdo.'

--- a/app/views/admin/cycles/plugin_relations/petitions/index.html.slim
+++ b/app/views/admin/cycles/plugin_relations/petitions/index.html.slim
@@ -39,8 +39,8 @@
          h3 Texto completo 
        .filters.clearfix
          .pull-right
-           = link_to 'Baixar documento', @petition.current_version.document_url, class: 'btn', target: '_blank' if @petition.current_version.document_url
-       - if @petition.current_version.body
+           = link_to 'Baixar documento', @petition.current_version.document_url, class: 'btn', target: '_blank' if @petition.current_version.document_url if @petition.current_version && @petition.current_version.published
+       - if @petition.current_version && @petition.current_version.published && @petition.current_version.body
          .plip-body= markdown @petition.current_version.body
 - else
   = 'Petição em branco, edite para adicionar conteúdo.'

--- a/app/views/cycles/plugin_relations/petition.html.slim
+++ b/app/views/cycles/plugin_relations/petition.html.slim
@@ -13,53 +13,58 @@ section.container-fluid#petition-index
       .col-xs-12
         h3 style="border-color: #{@cycle.color};"= @phase.description
 
-    - if @user_signed_petition
-      .row.medium-gap.text-center
+    - if @phase.plugin_relation.ready?
+      - if @user_signed_petition
+        .row.medium-gap.text-center
+          .col-xs-12
+            | Recebemos sua pré-assinatura! Por um requisito legal, agora você precisa baixar o App da Mudamos para confirmar a assinatura
+        .row.medium-gap.text-center
+          .col-xs-12.col-sm-6
+            a.store-badge.app href="#"
+          .col-xs-12.col-sm-6
+            a.store-badge.play href="#"
+      - else
+        .row
+          .col-xs-12.call-wrapper
+            .call-to-action.plip-sign
+              a.main-call.sign-petition style="border: 5px solid #{@cycle.color};" href='#'
+                span=@petition.call_to_action
+                span.action-tail style="border-top: 80px solid #{@cycle.color};" &nbsp
+                .hover-box style="background-color: #{@cycle.color};"
+
+      .row.medium-gap
         .col-xs-12
-          | Recebemos sua pré-assinatura! Por um requisito legal, agora você precisa baixar o App da Mudamos para confirmar a assinatura
-      .row.medium-gap.text-center
-        .col-xs-12.col-sm-6
-          a.store-badge.app href="#"
-        .col-xs-12.col-sm-6
-          a.store-badge.play href="#"
-    - else
+          .pull-right
+            strong Número de assinaturas necessárias: 
+            = @petition.signatures_required
       .row
-        .col-xs-12.call-wrapper
-          .call-to-action.plip-sign
-            a.main-call.sign-petition style="border: 5px solid #{@cycle.color};" href='#'
-              span=@petition.call_to_action
-              span.action-tail style="border-top: 80px solid #{@cycle.color};" &nbsp
-              .hover-box style="background-color: #{@cycle.color};"
+        .col-xs-12
+          = @petition.presentation
 
-    .row.medium-gap
-      .col-xs-12
-        .pull-right
-          strong Número de assinaturas necessárias: 
-          = @petition.signatures_required
-    .row
-      .col-xs-12
-        = @petition.presentation
+      .row.medium-gap
+        .col-xs-12.col-sm-2.share-col
+          div class="fb-share-button" data-layout="button_count" data-size="small" data-mobile-iframe="false"
+        .col-xs-12.col-sm-2.share-col
+          a href="https://twitter.com/share" class="twitter-share-button" data-size="small" data-lang="pt" data-show-count="true"
+        .col-xs-12.col-sm-4.share-col
+          a.download-document href=@petition.published_version.document_url target="_blank"
+            i.icon-baixeaqui style="color: #{@cycle.color};"
+            span Faça o Download da PLIP
 
-    .row.medium-gap
-      .col-xs-12.col-sm-2.share-col
-        div class="fb-share-button" data-layout="button_count" data-size="small" data-mobile-iframe="false"
-      .col-xs-12.col-sm-2.share-col
-        a href="https://twitter.com/share" class="twitter-share-button" data-size="small" data-lang="pt" data-show-count="true"
-      .col-xs-12.col-sm-4.share-col
-        a.download-document href=@petition.published_version.document_url target="_blank"
-          i.icon-baixeaqui style="color: #{@cycle.color};"
-          span Faça o Download da PLIP
+      .row.more-details-row
+        .col-xs-12
+          a.toggle-details.area-toggler href="#" style="color: #{@cycle.color};" data-container=".plip-row"
+            i class="icon-arrow"
+            | Saiba mais sobre esse projeto
 
-    .row.more-details-row
-      .col-xs-12
-        a.toggle-details.area-toggler href="#" style="color: #{@cycle.color};" data-container=".plip-row"
-          i class="icon-arrow"
-          | Saiba mais sobre esse projeto
+          hr.toggle-details
 
-        hr.toggle-details
+      .row.plip-row
+        .col-xs-12
+          h2.section-title.plip-title style="border-color: #{@cycle.color};" Detalhes sobre o Projeto de Lei de Iniciativa Popular
 
-    .row.plip-row
-      .col-xs-12
-        h2.section-title.plip-title style="border-color: #{@cycle.color};" Detalhes sobre o Projeto de Lei de Iniciativa Popular
-
-        .petition-container.plip-body= markdown @petition.published_version.body
+          .petition-container.plip-body= markdown @petition.published_version.body
+    - else
+        .row.medium-gap.text-center
+          .col-xs-12
+            ="Esta petição ainda não foi publicada, aguarde enquanto a edição do documento seja finalizada e tente novamento mais tarde."

--- a/app/views/cycles/plugin_relations/petition.html.slim
+++ b/app/views/cycles/plugin_relations/petition.html.slim
@@ -46,7 +46,7 @@ section.container-fluid#petition-index
       .col-xs-12.col-sm-2.share-col
         a href="https://twitter.com/share" class="twitter-share-button" data-size="small" data-lang="pt" data-show-count="true"
       .col-xs-12.col-sm-4.share-col
-        a.download-document href=@petition.current_version.document_url target="_blank"
+        a.download-document href=@petition.published_version.document_url target="_blank"
           i.icon-baixeaqui style="color: #{@cycle.color};"
           span Faça o Download da PLIP
 
@@ -62,4 +62,4 @@ section.container-fluid#petition-index
       .col-xs-12
         h2.section-title.plip-title style="border-color: #{@cycle.color};" Detalhes sobre o Projeto de Lei de Iniciativa Popular
 
-        .petition-container.plip-body= markdown @petition.current_version.body
+        .petition-container.plip-body= markdown @petition.published_version.body

--- a/config/initializers/prawn.rb
+++ b/config/initializers/prawn.rb
@@ -1,0 +1,1 @@
+Prawn::Font::AFM.hide_m17n_warning = true

--- a/config/initializers/shoryuken.rb
+++ b/config/initializers/shoryuken.rb
@@ -1,0 +1,7 @@
+Shoryuken.configure_server do |config|
+  # Replace Rails logger so messages are logged wherever Shoryuken is logging
+  # Note: this entire block is only run by the processor, so we don't overwrite
+  #       the logger when the app is running as usual.
+
+  Rails.logger = Shoryuken::Logging.logger
+end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -10,16 +10,33 @@
 # Make sure the secrets in this file are kept private
 # if you're sharing your code publicly.
 
+default: &default
+  queues:
+    petition_pdf_generation: <%= ENV["PETITION_PDF_GENERATION_QUEUE"] %>
+  
+  buckets:
+    petition_pdf: <%= ENV["PETITION_PDF_BUCKET"] %>
+
+  aws:
+    access_key_id: <%= ENV["AWS_ACCESS_KEY_ID"] %>
+    secret_access_key: <%= ENV["AWS_SECRET_ACCESS_KEY"] %>
+    region: <%= ENV["AWS_REGION"] %>
+
 development:
+  <<: *default
   secret_key_base: 1b3558fabd17afc3400af94e9ceee4d9bf6078dd37d29827ea39a1063a8541fe5b2b668ddd28f9084d9af6cd2bc9c78afc3656ea4214b48e4e7385fb5f0da850
 
 test:
+  <<: *default
   secret_key_base: ec4cedf9f5a4959e7937380b017c59bb456824f1a1b74c93e3919514754ae35cf8cad1f0cec7c204aa1e7c2a88866cca09f4135906c5f545c9729fdb24ebdc77
 
 staging:
+  <<: *default
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 production:
+  <<: *default
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+

--- a/config/shoryuken.yml
+++ b/config/shoryuken.yml
@@ -1,0 +1,5 @@
+concurrency: <%= ENV["SHORYUKEN_CONCURRENCY"] %>
+delay: <%= ENV["SHORYUKEN_DELAY"] %>
+queues:
+  # [ queue_name, priority ]
+  - [ <%= ENV["PETITION_PDF_GENERATION_QUEUE"] %>, <%= ENV["PETITION_PDF_GENERATION_QUEUE_PRIORITY"] || 1 %> ]

--- a/db/migrate/20170109184418_add_published_to_petition_plugin_detail_version.rb
+++ b/db/migrate/20170109184418_add_published_to_petition_plugin_detail_version.rb
@@ -1,0 +1,5 @@
+class AddPublishedToPetitionPluginDetailVersion < ActiveRecord::Migration
+  def change
+    add_column :petition_plugin_detail_versions, :published, :boolean, default: false
+  end
+end

--- a/db/migrate/20170109184851_drop_not_null_from_petition_plugin_detail_version_document_url.rb
+++ b/db/migrate/20170109184851_drop_not_null_from_petition_plugin_detail_version_document_url.rb
@@ -1,0 +1,5 @@
+class DropNotNullFromPetitionPluginDetailVersionDocumentUrl < ActiveRecord::Migration
+  def change
+    change_column :petition_plugin_detail_versions, :document_url, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170106153041) do
+ActiveRecord::Schema.define(version: 20170109184851) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -292,12 +292,13 @@ ActiveRecord::Schema.define(version: 20170106153041) do
   add_index "permissions", ["deleted_at"], name: "index_permissions_on_deleted_at", using: :btree
 
   create_table "petition_plugin_detail_versions", force: :cascade do |t|
-    t.integer  "petition_plugin_detail_id", null: false
-    t.string   "document_url",              null: false
-    t.text     "body",                      null: false
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
+    t.integer  "petition_plugin_detail_id",                 null: false
+    t.string   "document_url"
+    t.text     "body",                                      null: false
+    t.datetime "created_at",                                null: false
+    t.datetime "updated_at",                                null: false
     t.datetime "deleted_at"
+    t.boolean  "published",                 default: false
   end
 
   add_index "petition_plugin_detail_versions", ["deleted_at"], name: "index_petition_plugin_detail_versions_on_deleted_at", using: :btree

--- a/spec/factories/petition_plugin/detail_versions.rb
+++ b/spec/factories/petition_plugin/detail_versions.rb
@@ -2,5 +2,6 @@ FactoryGirl.define do
   factory :petition_plugin_detail_version, class: 'PetitionPlugin::DetailVersion' do
     body '== Projeto de lei'
     document_url 'http://projeto.bla'
+    published true
   end
 end

--- a/spec/jobs/petition_pdf_generation_worker_spec.rb
+++ b/spec/jobs/petition_pdf_generation_worker_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe PetitionPdfGenerationWorker do
+  let(:petition_pdf_service) { spy }
+  let(:worker) { described_class.new petition_pdf_service: petition_pdf_service }
+
+  describe "#perform" do
+    let!(:cycle) { create_cycle_with_phase phases: [{ plugin_type: :petition }] }
+    let!(:phase) { cycle.phases.first }
+    let!(:detail) { create :petition_plugin_detail, plugin_relation: phase.plugin_relation }
+    let!(:version) { create :petition_plugin_detail_version, petition_plugin_detail: detail, published: false }
+
+    let(:document_url) { "https://teste.s3-us-west-2.amazonaws.com/seguranca-publica-peticao-1-1.pdf" }
+
+    subject { worker.perform nil, "{ \"id\": #{version.id} }" }
+
+    before { allow(petition_pdf_service).to receive(:generate).and_return document_url }
+
+    it "generates the pdf and publishs the version" do
+
+      aggregate_failures do
+        subject
+        expect(version.reload.published).to eq true
+        expect(version.reload.document_url).to eq document_url
+      end
+    end
+
+    context "when the body is invalid" do
+      subject { worker.perform nil, "{" }
+
+      it { expect { subject }.to raise_error JSON::ParserError }
+    end
+
+    context "when the record does not exists" do
+      subject { worker.perform nil, "{ \"id\": -1 }" }
+
+      it { expect { subject }.to raise_error ActiveRecord::RecordNotFound }
+    end
+  end
+end

--- a/spec/jobs/petition_pdf_generation_worker_spec.rb
+++ b/spec/jobs/petition_pdf_generation_worker_spec.rb
@@ -6,13 +6,12 @@ RSpec.describe PetitionPdfGenerationWorker do
   let(:worker) { described_class.new petition_pdf_service: petition_pdf_service, repository: detail_version_repository }
 
   describe "#perform" do
-    let(:version) { instance_spy PetitionPlugin::Detail }
+    let(:version) { spy PetitionPlugin::Detail.new, id: 1 }
 
     let(:document_url) { "https://teste.s3-us-west-2.amazonaws.com/seguranca-publica-peticao-1-1.pdf" }
 
     before do
       allow(petition_pdf_service).to receive(:generate).and_return document_url
-      allow(version).to receive(:id).and_return 1
       allow(detail_version_repository).to receive(:find_by_id!).with(version.id).and_return(version)
     end
 


### PR DESCRIPTION
This PR closes #81 and #79

### How was it before?

- the petition pdf creation and upload had to be handled manually

### What has changed?

- the petition pdf is automatically generated and upload to s3
- the petition phase nows only starts when the pdf is generated and uploaded (fixes #79)

### What should I pay attention when reviewing this PR?

Nothing special

### Is this PR dangerous?

kind of, since it changes a lot of code.
