### PR TITLE
Removing strikethrough from the markdown editor (Issue 90)

### DIFF
--- a/app/assets/javascripts/admin/init-simplemde.js
+++ b/app/assets/javascripts/admin/init-simplemde.js
@@ -3,6 +3,9 @@
     $('.markdown-input').each(function() {
       new SimpleMDE({
         element: this,
+        parsingConfig: {
+          strikethrough: false
+        },
         toolbar: ["bold", "italic", "heading", "|", "quote", "unordered-list", "ordered-list", "|", "guide"]
       });
     });


### PR DESCRIPTION
This PR closes #90

### How was it before?

- the markdown editor supported the strikethrough feature on its previewer

### What has changed?

- the support was removed since the parser does not support the feature

### What should I pay attention when reviewing this PR?

Nothing special

### Is this PR dangerous?

No.
