### PR TITLE
Access to old petition versions (Issue 82 and 92)

### DIFF
--- a/app/models/petition_plugin/detail.rb
+++ b/app/models/petition_plugin/detail.rb
@@ -26,6 +26,10 @@ class PetitionPlugin::Detail < ActiveRecord::Base
 
   validate :plugin_type_petition
 
+  def past_versions
+    petition_detail_versions.where "created_at < ?", published_version.created_at
+  end
+
   def current_version
     petition_detail_versions.last
   end

--- a/app/views/admin/cycles/plugin_relations/petitions/index.html.slim
+++ b/app/views/admin/cycles/plugin_relations/petitions/index.html.slim
@@ -45,5 +45,26 @@
              = 'Nenhuma versão publicada ainda'
        - if @petition.current_version
          .plip-body= markdown @petition.current_version.body
+ .row
+   .col-xs-12
+     .card-module
+       .title
+         h3
+           a#past_versions_title href="#"
+             | Versões anteriores
+       div#past_versions style="display: none"
+         ul.list-unstyled
+           - @petition.petition_detail_versions.each do |version|
+             li
+               - if version.published
+                 = link_to version.created_at.strftime("%d/%m/%Y - %H:%M"), version.document_url
+               - else
+                 = "#{version.created_at.strftime("%d/%m/%Y - %H:%M")} (Versão não publicada)"
+   javascript:
+     $("#past_versions_title").click(function(e) {
+       $("#past_versions").slideToggle();
+       e.preventDefault();
+       return false;
+     });
 - else
   = 'Petição em branco, edite para adicionar conteúdo.'

--- a/app/views/admin/cycles/plugin_relations/petitions/index.html.slim
+++ b/app/views/admin/cycles/plugin_relations/petitions/index.html.slim
@@ -45,26 +45,24 @@
              = 'Nenhuma versão publicada ainda'
        - if @petition.current_version
          .plip-body= markdown @petition.current_version.body
- .row
-   .col-xs-12
-     .card-module
-       .title
-         h3
-           a#past_versions_title href="#"
-             | Versões anteriores
-       div#past_versions style="display: none"
-         ul.list-unstyled
-           - @petition.petition_detail_versions.each do |version|
-             li
-               - if version.published
+ - if @petition.past_versions.length > 0 
+   .row
+     .col-xs-12
+       .card-module
+         .title
+           h3
+             a#past_versions_title href="#"
+               | Versões anteriores
+         div#past_versions style="display: none"
+           ul.list-unstyled
+             - @petition.past_versions.each do |version|
+               li
                  = link_to version.created_at.strftime("%d/%m/%Y - %H:%M"), version.document_url
-               - else
-                 = "#{version.created_at.strftime("%d/%m/%Y - %H:%M")} (Versão não publicada)"
-   javascript:
-     $("#past_versions_title").click(function(e) {
-       $("#past_versions").slideToggle();
-       e.preventDefault();
-       return false;
-     });
+     javascript:
+       $("#past_versions_title").click(function(e) {
+         $("#past_versions").slideToggle();
+         e.preventDefault();
+         return false;
+       });
 - else
   = 'Petição em branco, edite para adicionar conteúdo.'

--- a/app/views/cycles/plugin_relations/petition.html.slim
+++ b/app/views/cycles/plugin_relations/petition.html.slim
@@ -64,7 +64,25 @@ section.container-fluid#petition-index
           h2.section-title.plip-title style="border-color: #{@cycle.color};" Detalhes sobre o Projeto de Lei de Iniciativa Popular
 
           .petition-container.plip-body= markdown @petition.published_version.body
+
+      - if @petition.past_versions.length > 0
+        .row.medium-gap
+          .col-xs-12
+            h4 style="border-color: #{@cycle.color};"
+              a#past_versions_title href="#" Versões anteriores
+            div#past_versions style="display: none"
+              ul.list-unstyled
+                - @petition.past_versions.each do |version|
+                  li
+                    = link_to version.created_at.strftime("%d/%m/%Y - %H:%M"), version.document_url
+
     - else
         .row.medium-gap.text-center
           .col-xs-12
             ="Esta petição ainda não foi publicada, aguarde enquanto a edição do documento seja finalizada e tente novamento mais tarde."
+javascript:
+  $("#past_versions_title").click(function(e) {
+    $("#past_versions").slideToggle();
+    e.preventDefault();
+    return false;
+  });


### PR DESCRIPTION
This PR closes #82 and #92

### How was it before?

- the user was not able to access old versions of the petition

### What has changed?

- now there is a section which lists the old versions of the petition (when they exists) on the admin and on the end user site. 

### What should I pay attention when reviewing this PR?

Nothing special

### Is this PR dangerous?

No

### Prints

#### Admin
![past_versions](https://cloud.githubusercontent.com/assets/835641/21887944/417e6bb0-d8a9-11e6-85dc-9d5a28260f60.png)

#### End user site
![past_versions_front_end](https://cloud.githubusercontent.com/assets/835641/21887945/417f0d72-d8a9-11e6-9ceb-e3437888d992.png)
