### PR TITLE
Adding remaining days to the petition page (issue 105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR #105]: Adding remaining days to the petition page (issue 105)
 * [PR #106]: Fixing system handling of cycle creation when some plugin is not selected by the user
 * [PR #113]: Fixing blog post creation
 * [PR #104]: Sending message for user synchronization with the mobile platform (Issue 98) 

--- a/app/models/phase.rb
+++ b/app/models/phase.rb
@@ -83,6 +83,9 @@ class Phase < ActiveRecord::Base
     end
   end
 
+  def remaining_days
+    ((final_date - initial_date) / 60 / 60 / 24).to_i
+  end
 
   # validates_attachment :picture, presence: true, content_type: { content_type: ['image/jpeg', 'image/gif', 'image/png', 'image/jpg'] }
   validates_presence_of :name, :description, :initial_date, :final_date, :cycle

--- a/app/models/phase.rb
+++ b/app/models/phase.rb
@@ -84,7 +84,7 @@ class Phase < ActiveRecord::Base
   end
 
   def remaining_days
-    ((final_date - initial_date) / 60 / 60 / 24).to_i
+    (final_date.to_date - initial_date.to_date).to_i
   end
 
   # validates_attachment :picture, presence: true, content_type: { content_type: ['image/jpeg', 'image/gif', 'image/png', 'image/jpg'] }

--- a/app/views/cycles/plugin_relations/petition.html.slim
+++ b/app/views/cycles/plugin_relations/petition.html.slim
@@ -37,6 +37,13 @@ section.container-fluid#petition-index
           .pull-right
             strong Número de assinaturas necessárias: 
             = @petition.signatures_required
+
+      - if @phase.in_progress?
+        .row
+          .col-xs-12
+            .pull-right
+              strong Dias restantes: 
+              = @phase.remaining_days
       .row
         .col-xs-12
           = @petition.presentation


### PR DESCRIPTION
This PR closes #105

### How was it before?

- the petitions page did not showed how many days was remaining to the end of the petition

### What has changed?

- a simple counter was added to the petition page

### What should I pay attention when reviewing this PR?

Nothing special

### Is this PR dangerous?

no

### Printscreen

![number_of_days](https://cloud.githubusercontent.com/assets/835641/22081111/6dd5913e-dda9-11e6-8942-ac8c688ecd42.png)
