### PR TITLE
Fixing remaining days on phase (issue 30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR #132]: Fixing remaining days on phase (issue 30)
 * [PR #123]: Petition widget (issue 97)
  - Configure a cron to update the cache of the petitions information
  - Set `API_CACHE_EXPIRES_IN`

--- a/app/models/phase.rb
+++ b/app/models/phase.rb
@@ -84,7 +84,7 @@ class Phase < ActiveRecord::Base
   end
 
   def remaining_days
-    (final_date.to_date - initial_date.to_date).to_i
+    (final_date.to_date - Date.today).to_i
   end
 
   # validates_attachment :picture, presence: true, content_type: { content_type: ['image/jpeg', 'image/gif', 'image/png', 'image/jpg'] }

--- a/app/models/phase.rb
+++ b/app/models/phase.rb
@@ -84,7 +84,7 @@ class Phase < ActiveRecord::Base
   end
 
   def remaining_days
-    (final_date.to_date - Date.today).to_i
+    [0, (final_date.to_date - Date.today).to_i].max
   end
 
   # validates_attachment :picture, presence: true, content_type: { content_type: ['image/jpeg', 'image/gif', 'image/png', 'image/jpg'] }

--- a/spec/models/phase_spec.rb
+++ b/spec/models/phase_spec.rb
@@ -204,4 +204,12 @@ RSpec.describe Phase, type: :model do
       it { is_expected.to be true } 
     end
   end
+
+  describe "#remaining_days" do
+    let(:phase) { build :phase, initial_date: Date.today - 2, final_date: Date.today + 2 }
+
+    subject { phase.remaining_days }
+
+    it { is_expected.to be 2 }
+  end
 end

--- a/spec/models/phase_spec.rb
+++ b/spec/models/phase_spec.rb
@@ -211,5 +211,10 @@ RSpec.describe Phase, type: :model do
     subject { phase.remaining_days }
 
     it { is_expected.to be 2 }
+
+    context "when the phase has long been finished" do
+      let(:phase) { build :phase, initial_date: Date.today - 4, final_date: Date.today - 2 }
+      it { is_expected.to be 0 }
+    end
   end
 end


### PR DESCRIPTION
This PR closes #130

### How was it before?

- the application was calculating the remaining days wrong, it was using the phase's final date and initial date

### What has changed?

- the bug was fixed, now the application uses the correct date, the phase's final date and today's date

### What should I pay attention when reviewing this PR?

Nothing special

### Is this PR dangerous?

no