### PR TITLE
Adding metatag for itunes smart banner (issue 133)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* [PR #135]: Adding metatag for itunes smart banner (issue 133)
+ - Set `MOBILE_API_ID_IOS`
 * [PR #131]: New petition's page (Issue 96)
 * [PR #132]: Fixing remaining days on phase (issue 30)
 * [PR #123]: Petition widget (issue 97)

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Follow the instructions, and use the created user to access the admin area.
   - 'MOBILE_API_URL': The Mobile API url
   - 'MOBILE_API_TIMEOUT': The ammount in seconds the system will use as timeout when trying to communicate with the Mobile API 
   - `API_CACHE_EXPIRES_IN`: The ammount in minutes that the system will use to expire requests from the Mobile API
+  - `MOBILE_API_ID_IOS`: The iOs Mobile app id
 
 ### Queue configurations
 

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -9,6 +9,8 @@ html
 
     = favicon_link_tag
 
+    meta name="apple-itunes-app" content="app-id=#{Rails.application.secrets.mobile_app_id["ios"]}"
+
     meta name="viewport" content="width=device-width, initial-scale=0.7, maximum-scale=0.7, user-scalable=no"
 
     = metamagic site: "Mudamos", title: [:title, :site], separator: " | "

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -32,6 +32,9 @@ default: &default
   http_cache:
     api_expires_in: <%= ENV["API_CACHE_EXPIRES_IN"] || 1 %>
 
+  mobile_app_id:
+    ios: <%= ENV["MOBILE_API_ID_IOS"] || "1071484944" %>
+
 development:
   <<: *default
   secret_key_base: 1b3558fabd17afc3400af94e9ceee4d9bf6078dd37d29827ea39a1063a8541fe5b2b668ddd28f9084d9af6cd2bc9c78afc3656ea4214b48e4e7385fb5f0da850


### PR DESCRIPTION
This PR closes #133

### How was it before?

- the application didn't had any reference to the mobile app

### What has changed?

- the meta tag provided by apple was added, it render a smart banner to the app on the itunes

### What should I pay attention when reviewing this PR?

Nothing special

### Is this PR dangerous?

no