### PR TITLE
Removing user field requirements (Issue 126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR #142]: Removing user field requirements (Issue 126)
 * [PR #141]: Fixing past versions popover order and layout (issue 140)
 * [PR #137]: Fixing app's protocol configuration
 * [PR #135]: Adding metatag for itunes smart banner (issue 133)

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -12,6 +12,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
     render 'cycles/index'
   end
 
+  def edit
+    render 'users/registrations/edit', layout: 'application'
+  end
+
   def create
     begin
       build_resource sign_up_params

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -342,8 +342,6 @@ class User < ActiveRecord::Base
   validates_attachment :picture, content_type: { content_type: ["image/jpeg", "image/gif", "image/png", "image/jpg"] }, unless: -> { self.first_step }
 
   validates_presence_of :name
-  validates_presence_of :birthday, unless: -> { self.is_admin }
-  validates_presence_of :state, :city, :profile, :profile_id, :gender, unless: -> { self.first_step or self.is_admin }
   validates_presence_of :sub_profile,:sub_profile_id, unless: -> {(self.profile.nil? || self.profile.children_count == 0) or self.is_admin}
 
   validates_uniqueness_of :encrypted_alias_name, unless: -> { self.first_step or self.is_admin }

--- a/app/views/users/registrations/edit.html.slim
+++ b/app/views/users/registrations/edit.html.slim
@@ -1,4 +1,4 @@
-section.container-flui#user-edit
+section.container-fluid#user-edit
   .container
     .row
       .col-sm-8.col-sm-offset-2.col-xs-12


### PR DESCRIPTION
This PR closes #126

### How was it before?

- the had to input a lot of information upon registration, like birthday date, gender and etc
- the profile edition page was with error

### What has changed?

- the requirements was removed, leaving only name, email and password required for the registration
- the profile edition page was fixed

### What should I pay attention when reviewing this PR?

Nothing special

### Is this PR dangerous?

no