### PR TITLE
Adding a partner api for user creation (issue 146)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR #147]: Adding a partner api for user creation (issue 146)
 * [PR #143]: Adding oath authentication for partners API (Issue 127)
  - Run `rake db:migrate`
 * [PR #142]: Removing user field requirements (Issue 126)

--- a/app/controllers/partners_api/users_controller.rb
+++ b/app/controllers/partners_api/users_controller.rb
@@ -1,11 +1,20 @@
 class PartnersApi::UsersController < PartnersApi::ApplicationController
+
+  attr_reader :user_service
+
+  def initialize(user_service: UserService.new)
+    @user_service = user_service
+  end
+
   def create
     user_params = params.permit(:email, :name, :encrypted_password)
-
-    user = User.new(name: user_params["name"], email: user_params["email"], password: user_params["encrypted_password"])
+    user = user_service.create_user_with_password(
+      email: user_params["email"],
+      name: user_params["name"],
+      encrypted_password: user_params["encrypted_password"]
+    )
     
-    if user.save
-      user.update_attribute :encrypted_password, user_params["encrypted_password"]
+    if user.valid?
       head 204
     else
       render json: user.errors, status: 422

--- a/app/controllers/partners_api/users_controller.rb
+++ b/app/controllers/partners_api/users_controller.rb
@@ -26,8 +26,7 @@ class PartnersApi::UsersController < PartnersApi::ApplicationController
     )
     
     if user.valid?
-      plips = plip_repository.all_initiated(page: 1, limit: 1).items
-      current_plip = plips.last
+      current_plip = plip_repository.current_plip
 
       if current_plip.present?
         petition_detail_version = petition_plugin_detail_version_repository.find_by_id!(current_plip.id)

--- a/app/controllers/partners_api/users_controller.rb
+++ b/app/controllers/partners_api/users_controller.rb
@@ -1,0 +1,14 @@
+class PartnersApi::UsersController < PartnersApi::ApplicationController
+  def create
+    user_params = params.permit(:email, :name, :encrypted_password)
+
+    user = User.new(name: user_params["name"], email: user_params["email"], password: user_params["encrypted_password"])
+    
+    if user.save
+      user.update_attribute :encrypted_password, user_params["encrypted_password"]
+      head 204
+    else
+      render json: user.errors, status: 422
+    end
+  end
+end

--- a/app/repositories/plip_repository.rb
+++ b/app/repositories/plip_repository.rb
@@ -1,6 +1,11 @@
 class PlipRepository
   include Repository
 
+  def current_plip
+    plips = all_initiated(page: 1, limit: 1).items
+    current_plip = plips.last
+  end
+
   def all_initiated(page: 1, limit: 10)
 
     phases = Phase

--- a/app/services/user_service.rb
+++ b/app/services/user_service.rb
@@ -1,0 +1,11 @@
+class UserService
+  def create_user_with_password(email:, name:, encrypted_password:)
+    user = User.new(name: name, email: email, password: encrypted_password)
+    
+    if user.save
+      user.update_attribute :encrypted_password, encrypted_password
+    end
+
+    user
+  end
+end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,4 +43,6 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   Paperclip::Attachment.default_options[:path] = "#{Rails.root}/spec/test_files/:class/:id_partition/:style.:extension"
+
+  routes.default_url_options = { host: "localhost:3000", protocol: "http" }
 end

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -4,7 +4,7 @@ Doorkeeper.configure do
 
   # This block will be called to check whether the resource owner is authenticated or not.
   resource_owner_authenticator do
-    current_user || redirect_to(login_url)
+    current_user || redirect_to(root_url)
   end
 
   admin_authenticator do |routes|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -112,6 +112,7 @@ Rails.application.routes.draw do
 
   namespace :partners_api do
     resources :petitions, only: [:show]
+    resources :users, only: [:create]
   end  
 
   devise_for :users, controllers: {

--- a/spec/repositories/plip_repository_spec.rb
+++ b/spec/repositories/plip_repository_spec.rb
@@ -48,4 +48,14 @@ RSpec.describe PlipRepository do
       end
     end
   end
+
+  describe "#current_plip" do
+    let!(:cycle_one) { create_cycle_with_phase phases: [{ plugin_type: :petition, with_petition_information: true }] }
+    let!(:cycle_two) { create_cycle_with_phase phases: [{ plugin_type: :petition, with_petition_information: true }] }
+    let(:petition_version_id) { cycle_one.phases.first.plugin_relation.petition_detail.current_version.id }
+
+    subject { repository.current_plip }
+
+    it { expect(subject.id).to eq petition_version_id }
+  end
 end


### PR DESCRIPTION
This PR closes #146

### How was it before?

- the partners did not had any means to send their users to mudamos

### What has changed?

- an api was added for the partners to create users on mudamos-web platform

### What should I pay attention when reviewing this PR?

Nothing special

### Is this PR dangerous?

no