### PR TITLE
Adding page url on the payload to the petition mobile api synchronization (issue 150)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR #151]: Adding page url on the payload to the petition mobile api synchronization (issue 150)
 * [PR #145]: Adding signers widget on petition's page (Issue 109)
 * [PR #143]: Adding oath authentication for partners API (Issue 127)
  - Run `rake db:migrate`

--- a/app/services/mobile_api_service.rb
+++ b/app/services/mobile_api_service.rb
@@ -17,10 +17,18 @@ class MobileApiService
   end
 
   def register_petition_version(petition_detail_version)
+    phase = petition_detail_version.petition_plugin_detail.plugin_relation.related
+
+    page_url = Rails.application.routes.url_helpers.cycle_plugin_relation_url(
+      phase.cycle,
+      phase.plugin_relation
+    )
+
     post("/petition/register", petition: {
       id_petition: petition_detail_version.petition_plugin_detail_id,
       id_version: petition_detail_version.id,
       url: petition_detail_version.document_url,
+      page_url: page_url,
       sha: petition_detail_version.sha
     })
   end


### PR DESCRIPTION
This PR closes #150

### How was it before?

- the petition synchronization with the mobile api lacked the petition's page url

### What has changed?

- the page url was added to the payload sent to the mobile api

### What should I pay attention when reviewing this PR?

Nothing special

### Is this PR dangerous?

no