### PR TITLE
Fixing the exhibition of the petition information (Issue 159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR #164]: Fixing the exhibition of the petition information (Issue 159)
 * [PR #149]: New petition's pdf (Issue 149)
 * [PR #124]: Petition widget builder (Issue 124)
 * [PR #155]: Creating smartbanner for the platform and adding it to the petition's page (issue 134)

--- a/app/services/mobile_api_service.rb
+++ b/app/services/mobile_api_service.rb
@@ -42,7 +42,7 @@ class MobileApiService
     return nil unless body
 
     PetitionInfo.new(
-      Time.parse(body["updatedAt"]),
+      body["updatedAt"].present? ? Time.parse(body["updatedAt"]) : nil,
       body["signaturesCount"],
       body["blockchainAddress"]
     )

--- a/app/views/cycles/plugin_relations/petition.html.slim
+++ b/app/views/cycles/plugin_relations/petition.html.slim
@@ -62,8 +62,6 @@ section#petition-index
               |  do projeto
             div.medium-padded
               small.last_version_date
-                | A versão atual for criada no dia
-                span
             - if @petition.past_versions.length > 0
               div.medium-padded
                 a.past-versions href="javascript:void(0)" style="color: #{@cycle.color}" Veja versões anteriores
@@ -155,7 +153,11 @@ javascript:
   
         apiClient.getPetitionInfo(#{@petition.id}).then(function(petitionInfo) {
           if (petitionInfo) {
-            $(".last_version_date span").text(moment(petitionInfo.updated_at).format(" DD/MM/YYYY à\\s HH:mm"));
+            if (petitionInfo.updated_at) {
+              $(".last_version_date").text("A versão atual for criada no dia " + moment(petitionInfo.updated_at).format("DD/MM/YYYY à\\s HH:mm"));
+            } else {
+              $(".last_version_date").text("");
+            }
 
             var count = petitionInfo.signatures_count;
   


### PR DESCRIPTION
This PR closes #159

### How was it before?

- the API call was breaking when the `updatedAt` was nil on the mobile-api
- the label `A versão atual for criada no dia` was being wrong assembled when the updatedAt was missing from the api result

### What has changed?

- both cases were handled

### What should I pay attention when reviewing this PR?

everthing

### Is this PR dangerous?

no
