### PR TITLE
Extension was missing on the petition widget watermark image (issue 167)

### DIFF
--- a/app/views/embedded/petitions/show.html.slim
+++ b/app/views/embedded/petitions/show.html.slim
@@ -8,7 +8,7 @@ html
           h3= phase.name
           p= phase.description
           div.signers
-          = image_tag "watermark", class: "watermark"
+          = image_tag "watermark.png", class: "watermark"
 
       div.petition-progress-container
         - if phase.finished?


### PR DESCRIPTION
This PR closes #167

### How was it before?

- the petition's widget watermark image breaks on the heroku

### What has changed?

- the image was fixed

### What should I pay attention when reviewing this PR?

everthing

### Is this PR dangerous?

no
