### PR TITLE
Fixing final date on phases (issue 171)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* [PR #172]: Fixing final date on phases (issue 171)
+ - rake phases:ends_on_the_end_of_the_day
 * [PR #168]: Extension was missing on the petition widget watermark image (issue 167)
 * [PR #165]: Adding limit to plips api (Issue 161)
 * [PR #163]: Requesting missing information from the user on plugin interaction (Issue 144)

--- a/app/controllers/admin/cycles_controller.rb
+++ b/app/controllers/admin/cycles_controller.rb
@@ -81,6 +81,7 @@ class Admin::CyclesController < Admin::ApplicationController
     
     empty_plugin_relation = false
     @cycle.phases.map do |x|
+      x.final_date = x.final_date.try(:end_of_day)
       x.cycle = @cycle
 
       if x.plugin_relation
@@ -121,6 +122,7 @@ class Admin::CyclesController < Admin::ApplicationController
 
     empty_plugin_relation = false
     @cycle.phases.map do |x|
+      x.final_date = x.final_date.try(:end_of_day)
       x.cycle = @cycle
 
       if x.plugin_relation

--- a/app/controllers/api/entities_helpers.rb
+++ b/app/controllers/api/entities_helpers.rb
@@ -3,5 +3,9 @@ module Api
     Grape::Entity.format_with :iso_date do |date|
       date.to_date.iso8601 if date
     end
+
+    Grape::Entity.format_with :iso_date_time do |date|
+      date.iso8601 if date
+    end
   end
 end

--- a/app/controllers/api/v2/entities/phase.rb
+++ b/app/controllers/api/v2/entities/phase.rb
@@ -12,7 +12,7 @@ module Api
         expose :description
         expose :current_status, as: :status
 
-        with_options format_with: :iso_date do
+        with_options format_with: :iso_date_time do
           expose :initial_date
           expose :final_date
         end

--- a/app/controllers/api/v2/entities/phase.rb
+++ b/app/controllers/api/v2/entities/phase.rb
@@ -41,7 +41,7 @@ module Api
 
           property :initial_date do
             key :type, :string
-            format "ISO date"
+            format "ISO date time"
           end
 
           property :final_date do

--- a/app/controllers/api/v2/entities/phase.rb
+++ b/app/controllers/api/v2/entities/phase.rb
@@ -46,7 +46,7 @@ module Api
 
           property :final_date do
             key :type, :string
-            format "ISO date"
+            format "ISO date time"
           end
         end
       end

--- a/app/views/cycles/plugin_relations/petition.html.slim
+++ b/app/views/cycles/plugin_relations/petition.html.slim
@@ -48,8 +48,11 @@ section#petition-index
             .pull-left
               i.icon-clock style="color: #{@cycle.color}"
             div.medium-padded
-              strong= "#{@phase.remaining_days} dias "
-              | restantes para o encerramento
+              - if @phase.remaining_days > 0
+                strong= "#{@phase.remaining_days} #{@phase.remaining_days > 1 ? "dias restantes" : "dia restante"} "
+                | para o encerramento
+              - else
+                strong Último dia
             div.medium-padded
               small= "As colaborações podem ser feitas até o dia #{@phase.final_date.strftime("%d/%m/%Y")}" 
 
@@ -80,7 +83,10 @@ section#petition-index
 
         .row.phone-bottom-info
           .col-xs-6
-            strong= "#{@phase.remaining_days} dias restantes"
+            - if @phase.remaining_days > 0
+              strong= "#{@phase.remaining_days} #{@phase.remaining_days > 1 ? "dias restantes" : "dia restante"} "
+            - else
+              strong Último dia
             div
               small para o encerramento
           .col-xs-6

--- a/app/views/cycles/plugin_relations/petition.html.slim
+++ b/app/views/cycles/plugin_relations/petition.html.slim
@@ -43,18 +43,19 @@ section#petition-index
             | assinaturas para a meta de
             strong=" #{@petition.signatures_required}"
 
-        .row.small-gap.remaining-days.bottom-info-container
-          .col-xs-12
-            .pull-left
-              i.icon-clock style="color: #{@cycle.color}"
-            div.medium-padded
-              - if @phase.remaining_days > 0
-                strong= "#{@phase.remaining_days} #{@phase.remaining_days > 1 ? "dias restantes" : "dia restante"} "
-                | para o encerramento
-              - else
-                strong Último dia
-            div.medium-padded
-              small= "As colaborações podem ser feitas até o dia #{@phase.final_date.strftime("%d/%m/%Y")}" 
+        - if @phase.in_progress?
+          .row.small-gap.remaining-days.bottom-info-container
+            .col-xs-12
+              .pull-left
+                i.icon-clock style="color: #{@cycle.color}"
+              div.medium-padded
+                - if @phase.remaining_days > 0
+                  strong= "#{@phase.remaining_days} #{@phase.remaining_days > 1 ? "dias restantes" : "dia restante"} "
+                  | para o encerramento
+                - else
+                  strong Último dia
+              div.medium-padded
+                small= "As colaborações podem ser feitas até o dia #{@phase.final_date.strftime("%d/%m/%Y")}" 
 
         .row.small-gap.download-document.bottom-info-container
           .col-xs-12
@@ -82,13 +83,14 @@ section#petition-index
                       div.medium-padded= "Criada em #{version.created_at.strftime("%d/%m/%Y às %H:%M")}"
 
         .row.phone-bottom-info
-          .col-xs-6
-            - if @phase.remaining_days > 0
-              strong= "#{@phase.remaining_days} #{@phase.remaining_days > 1 ? "dias restantes" : "dia restante"} "
-            - else
-              strong Último dia
-            div
-              small para o encerramento
+          - if @phase.in_progress?
+            .col-xs-6
+              - if @phase.remaining_days > 0
+                strong= "#{@phase.remaining_days} #{@phase.remaining_days > 1 ? "dias restantes" : "dia restante"} "
+              - else
+                strong Último dia
+              div
+                small para o encerramento
           .col-xs-6
             strong.total-signatures
             div

--- a/lib/tasks/phases.rake
+++ b/lib/tasks/phases.rake
@@ -1,0 +1,10 @@
+namespace :phases do
+  desc "Sets the final date of the phase to the end of the day"
+  task ends_on_the_end_of_the_day: :environment do |_, args|
+    Phase.all.find_in_batches do |batch|
+      batch.each do |phase|
+        phase.update final_date: phase.final_date.end_of_day
+      end
+    end
+  end
+end

--- a/lib/tasks/phases.rake
+++ b/lib/tasks/phases.rake
@@ -1,6 +1,6 @@
 namespace :phases do
   desc "Sets the final date of the phase to the end of the day"
-  task ends_on_the_end_of_the_day: :environment do |_, args|
+  task ends_on_the_end_of_the_day: :environment do
     Phase.all.find_in_batches do |batch|
       batch.each do |phase|
         phase.update final_date: phase.final_date.end_of_day


### PR DESCRIPTION
This PR closes #171

### How was it before?

 - when the phase was saved it's final date was being set to the start of the day

### What has changed?

 - now the phase final date is always set to the end of the day
 - improved the petition message for the remaining days

### What should I pay attention when reviewing this PR?

everthing

### Is this PR dangerous?

no