### PR TITLE
Hiding the pre signature button when the phase is not in progress (issue 173)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR #174]: Hiding the pre signature button when the phase is not in progress (issue 173)
 * [PR #168]: Extension was missing on the petition widget watermark image (issue 167)
 * [PR #165]: Adding limit to plips api (Issue 161)
 * [PR #163]: Requesting missing information from the user on plugin interaction (Issue 144)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,7 +34,7 @@ class ApplicationController < ActionController::Base
   private
 
     def plugin_type_repository
-      @plugin_relation_repository ||= PluginTypeRepository.new
+      @plugin_type_repository ||= PluginTypeRepository.new
     end
 
     def set_cycles

--- a/app/controllers/cycles/plugin_relations/petitions_controller.rb
+++ b/app/controllers/cycles/plugin_relations/petitions_controller.rb
@@ -8,13 +8,13 @@ class Cycles::PluginRelations::PetitionsController < ApplicationController
     @petition_signer ||= PetitionPlugin::PetitionSigner.new
   end
 
-  attr_writer :plugin_relation_repository
-
   def plugin_relation_repository
     @plugin_relation_repository ||= PluginRelationRepository.new
   end
 
   def sign
+    return render json: { error: "Fase terminada" }, status: 403 unless plugin_relation.related.in_progress?
+
     petition_signer.perform user_id: current_user.id, plugin_relation_id: plugin_relation.id
 
     flash[:success] = "Petição assinada!"

--- a/app/controllers/cycles/plugin_relations/petitions_controller.rb
+++ b/app/controllers/cycles/plugin_relations/petitions_controller.rb
@@ -8,6 +8,8 @@ class Cycles::PluginRelations::PetitionsController < ApplicationController
     @petition_signer ||= PetitionPlugin::PetitionSigner.new
   end
 
+  attr_writer :plugin_relation_repository
+
   def plugin_relation_repository
     @plugin_relation_repository ||= PluginRelationRepository.new
   end

--- a/app/views/cycles/plugin_relations/petition.html.slim
+++ b/app/views/cycles/plugin_relations/petition.html.slim
@@ -14,19 +14,20 @@ section#petition-index
       h3.petition-description= @phase.description
 
       - if @phase.plugin_relation.ready?
-        - if @user_signed_petition
-          .row
-            .col-xs-12
-              | Recebemos sua pré-assinatura! Por um requisito legal, agora você precisa baixar o App da Mudamos para confirmar a assinatura
-          .row.small-gap
-            .col-xs-12
-              a.store-badge.app href="#"
-              a.store-badge.play href="#"
-        - else
-          .row
-            .col-xs-12
-              button.rounded-button.sign-petition style="background-color: #{@cycle.color}"
-               =@petition.call_to_action
+        - if @phase.in_progress?
+          - if @user_signed_petition
+            .row
+              .col-xs-12
+                | Recebemos sua pré-assinatura! Por um requisito legal, agora você precisa baixar o App da Mudamos para confirmar a assinatura
+            .row.small-gap
+              .col-xs-12
+                a.store-badge.app href="#"
+                a.store-badge.play href="#"
+          - else
+            .row
+              .col-xs-12
+                button.rounded-button.sign-petition style="background-color: #{@cycle.color}"
+                 =@petition.call_to_action
 
         .row.signatures-info
           .col-xs-12.already-signed


### PR DESCRIPTION
This PR closes #173

### How was it before?

 - the pre signature button was being show even tough the phase had finished

### What has changed?

 - the button only shows now if the phase is in progress

### What should I pay attention when reviewing this PR?

everthing

### Is this PR dangerous?

no