### PR TITLE
Page to list petition's signatures pdf (Issue 110)

### DIFF
--- a/app/assets/stylesheets/petition.sass
+++ b/app/assets/stylesheets/petition.sass
@@ -309,3 +309,11 @@
 
   .verify-result
     display: none
+
+#petition-signatures
+  padding: 60px 0 60px 0
+  margin-top: 60px
+
+  .petition-signature
+    label
+      margin-right: 5px

--- a/app/assets/stylesheets/petition.sass
+++ b/app/assets/stylesheets/petition.sass
@@ -5,6 +5,10 @@
   height: 100%
   font-size: 22px
 
+  .view-all-signatures
+    text-transform: uppercase
+    margin-left: 5px
+
   .embedded-link
     height: 10px
     margin-bottom: 20px

--- a/app/controllers/petitions_controller.rb
+++ b/app/controllers/petitions_controller.rb
@@ -1,4 +1,19 @@
 class PetitionsController < ApplicationController
   def verify
   end
+
+  def signatures
+    @petition = petition_repository.find_by_id!(params[:petition_id])
+    @signatures = petition_service.fetch_petition_signatures(params[:petition_id])
+  end
+
+  private
+
+  def petition_service
+    @petition_service ||= PetitionService.new
+  end
+
+  def petition_repository
+    @petition_repository ||= PetitionPlugin::DetailRepository.new
+  end
 end

--- a/app/services/mobile_api_service.rb
+++ b/app/services/mobile_api_service.rb
@@ -73,6 +73,24 @@ class MobileApiService
     signers
   end
 
+  PetitionSignature = Struct.new(:file, :blockchain_transaction_id, :updated_at, :transaction_date, :blockstamp, :signature)
+  def petition_signatures(petition_id)
+    response = get("/petition/#{petition_id}/signatures")
+
+    signatures_json = JSON.parse(response.body)["data"]["signatures"]
+
+    signatures_json.map do |json|
+      PetitionSignature.new(
+         json["petition_file"],
+         json["petition_blockchain_transaction_id"],
+         json["petition_updatedat"],
+         json["petition_txstamp"] ? Time.parse(json["petition_txstamp"]) : nil,
+         json["petition_blockstamp"] ? Time.parse(json["petition_blockstamp"]) : nil,
+         json["petition_signature"]
+      )
+    end
+  end
+
   private
 
   [:get, :head].each do |verb|

--- a/app/services/mobile_api_service.rb
+++ b/app/services/mobile_api_service.rb
@@ -92,7 +92,7 @@ class MobileApiService
       PetitionSignature.new(
          json["petition_file"],
          json["petition_blockchain_transaction_id"],
-         json["petition_updatedat"],
+         json["petition_updatedat"] ? Time.parse(json["petition_updatedat"]) : nil,
          json["petition_txstamp"] ? Time.parse(json["petition_txstamp"]) : nil,
          json["petition_blockstamp"] ? Time.parse(json["petition_blockstamp"]) : nil,
          json["petition_signature"]

--- a/app/services/mobile_api_service.rb
+++ b/app/services/mobile_api_service.rb
@@ -82,7 +82,7 @@ class MobileApiService
     signers
   end
 
-  PetitionSignature = Struct.new(:file, :blockchain_transaction_id, :updated_at, :transaction_date, :blockstamp, :signature)
+  PetitionSignature = Struct.new(:pdf_url, :blockchain_transaction_id, :updated_at, :transaction_date, :blockstamp, :signature)
   def petition_signatures(petition_id)
     response = get("/petition/#{petition_id}/signatures")
 
@@ -90,7 +90,7 @@ class MobileApiService
 
     signatures_json.map do |json|
       PetitionSignature.new(
-         json["petition_file"],
+         json["petition_pdf_url"],
          json["petition_blockchain_transaction_id"],
          json["petition_updatedat"] ? Time.parse(json["petition_updatedat"]) : nil,
          json["petition_txstamp"] ? Time.parse(json["petition_txstamp"]) : nil,

--- a/app/services/petition_service.rb
+++ b/app/services/petition_service.rb
@@ -30,4 +30,12 @@ class PetitionService
       end
     end
   end
+
+  def fetch_petition_signatures(petition_id, fresh: false)
+    cache_key = "mobile_petition_signatures:#{petition_id}"
+
+    Rails.cache.fetch(cache_key, force: fresh) do
+      mobile_service.petition_signatures(petition_id)
+    end
+  end
 end

--- a/app/views/cycles/plugin_relations/petition.html.slim
+++ b/app/views/cycles/plugin_relations/petition.html.slim
@@ -100,6 +100,8 @@ section#petition-index
         .div.bottom-info-clear
 
         .row#petition-signers-desktop
+        .row.view-all-signatures
+          a href="#{petition_signatures_path(@petition)}" style="color: #{@cycle.color}" Confira as listas de assinaturas autenticadas
 
     .col-lg-6.petition-view.petition-body-container
       - if  @phase.plugin_relation.ready?

--- a/app/views/petitions/signatures.html.slim
+++ b/app/views/petitions/signatures.html.slim
@@ -1,0 +1,21 @@
+section.container-fluid#petition-signatures
+  .container
+    h1.section-title= "Assinaturas da petição \"#{@petition.plugin_relation.related.name}\""
+    - @signatures.each do |signature|
+      ul.list-unstyled.petition-signature
+        li
+          label Código da transação:
+          = "#{signature.blockchain_transaction_id}"
+        li
+          label Data de atualização:
+          = "#{signature.updated_at.strftime("%d/%m/%Y - %H:%M")}"
+        li
+          label Data da transação:
+          = "#{signature.transaction_date.strftime("%d/%m/%Y - %H:%M")}"
+        li
+          label Data de registro na Blockchain:
+          = "#{signature.blockstamp.strftime("%d/%m/%Y - %H:%M")}"
+        li
+          label Assinatura
+          = "#{signature.signature}"
+

--- a/app/views/petitions/signatures.html.slim
+++ b/app/views/petitions/signatures.html.slim
@@ -19,5 +19,5 @@ section.container-fluid#petition-signatures
           label Assinatura
           = "#{signature.signature}"
         li
-          a target="_blank" href="#{signature.file}" Baixe o PDF assinado
+          a target="_blank" href="#{signature.pdf_url}" Baixe o PDF assinado
 

--- a/app/views/petitions/signatures.html.slim
+++ b/app/views/petitions/signatures.html.slim
@@ -18,4 +18,6 @@ section.container-fluid#petition-signatures
         li
           label Assinatura
           = "#{signature.signature}"
+        li
+          a target="_blank" href="#{signature.file}" Baixe o PDF assinado
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -160,5 +160,6 @@ Rails.application.routes.draw do
 
   resources :petitions, only: [] do
     get :verify, on: :collection
+    get :signatures
   end
 end


### PR DESCRIPTION
This PR closes #110

### How was it before?

 - the user could not check the petition's signatures

### What has changed?

 - a simple page was created to list the petition's signatures

### What should I pay attention when reviewing this PR?

everthing

### Is this PR dangerous?

no

### 
![signatures](https://cloud.githubusercontent.com/assets/835641/23035007/e8a040b8-f464-11e6-8ad9-6b549098ecf8.png)
