### PR TITLE
Setting cache store to memory on stagging and production (Issue 178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR #179]: Setting cache store to memory on stagging and production (Issue 178)
 * [PR #175]: Adding page for verifying petition pdfs (Issue 158)
 * [PR #172]: Fixing final date on phases (issue 171)
  - rake phases:ends_on_the_end_of_the_day

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 * [PR #179]: Setting cache store to memory on stagging and production (Issue 178)
+  - Run `heroku addons:create memcachier:dev`
 * [PR #175]: Adding page for verifying petition pdfs (Issue 158)
 * [PR #172]: Fixing final date on phases (issue 171)
  - rake phases:ends_on_the_end_of_the_day

--- a/Gemfile
+++ b/Gemfile
@@ -122,6 +122,8 @@ end
 
 group :production, :staging do
   gem 'rails_12factor'
+  gem 'dalli'
+  gem 'memcachier'
 end
 
 group :production do

--- a/app/assets/javascripts/templates/petitions/valid.jst.ejs
+++ b/app/assets/javascripts/templates/petitions/valid.jst.ejs
@@ -2,5 +2,5 @@
 <ul class="list-unstyled">
   <li><label>Código da transação:</label><%= status.transaction %></li>
   <li><label>Data da transação:</label><%= moment(status.transaction_date).format("DD/MM/YYYY - h:mm:ss") %></li>
-  <li><label>Data de registro na Bockchain:</label><%= moment(status.blockstamp).format("DD/MM/YYYY - h:mm:ss") %></li>
+  <li><label>Data de registro na Blockchain:</label><%= moment(status.blockstamp).format("DD/MM/YYYY - h:mm:ss") %></li>
 </ul>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,7 +55,7 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :memory_store, { size: 64.megabytes }
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,7 +55,7 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
   # Use a different cache store in production.
-  config.cache_store = :memory_store, { size: 64.megabytes }
+  config.cache_store = :dalli_store
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -55,7 +55,7 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :memory_store, { size: 64.megabytes }
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -55,7 +55,7 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
   # Use a different cache store in production.
-  config.cache_store = :memory_store, { size: 64.megabytes }
+  config.cache_store = :dalli_store
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'


### PR DESCRIPTION
This PR closes #178

### How was it before?

 - the cache store was being configured to the default on all environments

http://guides.rubyonrails.org/caching_with_rails.html#activesupport-cache-memorystore

### What has changed?

 - now stagging and production uses mem cache store

### What should I pay attention when reviewing this PR?

everthing

### Is this PR dangerous?

no