### PR TITLE
Fix profile and birthday not being required (Issue 185)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR #186]: Fix profile and birthday not being required (Issue 185)
 * [PR #177]: Page to list petition's signatures pdf (Issue 110)
 * [PR #176]: Page to verify signatures (Issue 160)
 * [PR #181]: Change petition info api path (Issue 180)

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -62,8 +62,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
           end
         end
       end
+    # TODO: This is just stupid. Why would someone do something like this? :(
     rescue Exception => e
       puts "\n\n BUG NO LOGIN \n\n"
+      puts e.message
+      puts e.backtrace
     end
   end
 

--- a/app/use_cases/user_account_sync.rb
+++ b/app/use_cases/user_account_sync.rb
@@ -22,10 +22,10 @@ class UserAccountSync
       id: user.id,
       name: user.name,
       email: user.email,
-      profile: user.profile.name,
+      profile: user.profile.try(:name),
       sub_profile: user.sub_profile.try(:name),
       gender: user.gender,
-      birthday: user.birthday.strftime("%Y-%m-%d"),
+      birthday: user.birthday.try(:strftime, "%Y-%m-%d"),
       picture_url: user.picture.url,
       password: user.encrypted_password,
       cpf: user.cpf

--- a/spec/use_cases/user_account_sync_spec.rb
+++ b/spec/use_cases/user_account_sync_spec.rb
@@ -40,6 +40,24 @@ RSpec.describe UserAccountSync do
       it { expect{ subject }.to raise_error ArgumentError }
       it { expect(sqs_service).to_not have_received(:publish_message) }
     end
+
+    context "when the user does not have profile" do
+      before { user.profile = nil }
+
+      it do
+        subject
+        expect(sqs_service).to have_received(:publish_message).with queue_name, hash_including(profile: nil)
+      end
+    end
+
+    context "when the user does not have a birthday" do
+      before { user.birthday = nil }
+
+      it do
+        subject
+        expect(sqs_service).to have_received(:publish_message).with queue_name, hash_including(birthday: nil)
+      end
+    end
   end
 end
 


### PR DESCRIPTION
This PR closes #185.

### How was it before?

- the sign up would fail when trying to deliver a message to the user sync queue because the profile and birthday are not required anymore

### What has changed?

- when building the payload, the aforementioned attributes are not required

### What should I pay attention when reviewing this PR?

Nothing in particular.

### Is this PR dangerous?

No.