### PR TITLE
Add petition name to the petition register payload (Issue 184)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR #187]: Add petition name to the petition register payload (Issue 184)
 * [PR #186]: Fix profile and birthday not being required (Issue 185)
 * [PR #177]: Page to list petition's signatures pdf (Issue 110)
 * [PR #176]: Page to verify signatures (Issue 160)

--- a/app/services/mobile_api_service.rb
+++ b/app/services/mobile_api_service.rb
@@ -36,6 +36,7 @@ class MobileApiService
     post("/petition/register", petition: {
       id_petition: petition_detail_version.petition_plugin_detail_id,
       id_version: petition_detail_version.id,
+      name: phase.name,
       url: petition_detail_version.document_url,
       page_url: page_url,
       sha: petition_detail_version.sha


### PR DESCRIPTION
This PR closes #184.

### How was it before?

- the petition register mobile api payload did not include the petition name

### What has changed?

- it now does

### What should I pay attention when reviewing this PR?

Nothing in particular.

### Is this PR dangerous?

No.