### PR TITLE
Handle mobile api validation errors on /signatures (Issue 192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR #203]: Handle mobile api validation errors on /signatures (Issue 192)
 * [PR #191]: Revisar login - RETORNO bizarro textarea (Issue 188)
 * [PR #190]: Add mobile api namespace (Issue 189)
 * [PR #187]: Add petition name to the petition register payload (Issue 184)

--- a/app/services/mobile_api_service.rb
+++ b/app/services/mobile_api_service.rb
@@ -99,6 +99,8 @@ class MobileApiService
     )
 
     status
+  rescue ValidationError
+    nil
   end
 
   PetitionSignature = Struct.new(:pdf_url, :blockchain_transaction_id, :updated_at, :transaction_date, :blockstamp, :signature)

--- a/app/services/mobile_api_service.rb
+++ b/app/services/mobile_api_service.rb
@@ -10,6 +10,10 @@ class MobileApiService
       super(message)
       @validations = validations
     end
+
+    def to_s
+      "#{super} #{validations}"
+    end
   end
 
   def initialize(
@@ -99,7 +103,8 @@ class MobileApiService
     )
 
     status
-  rescue ValidationError
+  rescue ValidationError => e
+    Rails.logger.info e
     nil
   end
 


### PR DESCRIPTION
This PR closes #192.

### How was it before?

- the signatures page `/signatures/{id}` would not properly handle the mobile api validation errors when the given hash/id did not exist

### What has changed?

- the service now handles validation errors

### What should I pay attention when reviewing this PR?

Nothing in particular.

### Is this PR dangerous?

No.