### PR TITLE
Parsing the signature id as a base64 encoded data (Issue 204)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR #205]: Parsing the signature id as a base64 encoded data (Issue 204)
 * [PR #203]: Handle mobile api validation errors on /signatures (Issue 192)
 * [PR #191]: Revisar login - RETORNO bizarro textarea (Issue 188)
 * [PR #190]: Add mobile api namespace (Issue 189)

--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -1,12 +1,22 @@
+require "base64"
+
 class SignaturesController < ApplicationController
 
   def show
-    @signature = signature_service.fetch_signature_status(params[:id])
+    id = parse_signature_id(params[:id])
+    @signature = signature_service.fetch_signature_status(id) if id.present?
   end
 
   private
 
   def signature_service
     @signature_service ||= SignatureService.new
+  end
+
+  def parse_signature_id(text)
+    Base64.strict_decode64(text.to_s)
+  rescue ArgumentError
+    Rails.logger.info("Invalid signature")
+    nil
   end
 end


### PR DESCRIPTION
This PR closes #204.

### How was it before?

- id route received a the signature id but now it receives a base64 encoded one

### What has changed?

- we just parse data before using it

### What should I pay attention when reviewing this PR?

Parsing this data on the controller is not optimal, but it is simple enough for now. Later we can use an `use case` / `service object` to fetch the signature and parse it.

### Is this PR dangerous?

No.