### PR TITLE
Fix oauth lookup by the user email (Issue 201)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR #207]: Fix oauth lookup by the user email (Issue 201)
 * [PR #203]: Handle mobile api validation errors on /signatures (Issue 192)
 * [PR #191]: Revisar login - RETORNO bizarro textarea (Issue 188)
 * [PR #190]: Add mobile api namespace (Issue 189)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -199,7 +199,8 @@ class User < ActiveRecord::Base
     omniauth_identity = OmniauthIdentity.find_for_oauth(auth)
 
     user = signed_in_resource ? signed_in_resource : omniauth_identity.user
-    user ||= User.where(email: auth['info']['email']).first_or_initialize
+    # .find_by_email will automatically encrypt it before querying
+    user ||= User.find_by_email(email: auth['info']['email']) || User.new(email: auth['info']['email'])
 
     if user.persisted?
       if omniauth_identity.new_record?


### PR DESCRIPTION
This PR closes #201.

### How was it before?

- the facebook login would fail because a query by the user email was issued. We don't have an email column but an encrypted one.

### What has changed?

- the lookup is now performed on the `encrypted_email` column

### What should I pay attention when reviewing this PR?

Is there anything else missing?

### Is this PR dangerous?

No.