### PR TITLE
Parsing a hexadecimal string representing the signature (Issue 208)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR #209]: Parsing a hexadecimal string representing the signature (Issue 208)
 * [PR #207]: Fix oauth lookup by the user email (Issue 201)
 * [PR #203]: Handle mobile api validation errors on /signatures (Issue 192)
 * [PR #191]: Revisar login - RETORNO bizarro textarea (Issue 188)

--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -1,12 +1,20 @@
 class SignaturesController < ApplicationController
 
   def show
-    @signature = signature_service.fetch_signature_status(params[:id])
+    id = parse_signature_id(params[:id])
+    @signature = signature_service.fetch_signature_status(id) if id.present?
   end
 
   private
 
   def signature_service
     @signature_service ||= SignatureService.new
+  end
+
+  def parse_signature_id(text)
+    [text.to_s].pack("H*").encode("utf-8")
+  rescue Encoding::UndefinedConversionError
+    Rails.logger.info("Invalid hexadecimal signature: #{text}")
+    nil
   end
 end


### PR DESCRIPTION
This PR closes #208.

### How was it before?

- the signature endpoint received a string that represented the signature

### What has changed?

- now it receives a hex representation of it

### What should I pay attention when reviewing this PR?

Nothing in particular.

### Is this PR dangerous?

No.