### PR TITLE
Extension was missing on the smart banner icon (issue 212)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR #211]: Extension was missing on the smart banner icon (issue 212)
 * [PR #209]: Parsing a hexadecimal string representing the signature (Issue 208)
 * [PR #207]: Fix oauth lookup by the user email (Issue 201)
 * [PR #203]: Handle mobile api validation errors on /signatures (Issue 192)

--- a/app/views/widgets/_smart_banner.html.slim
+++ b/app/views/widgets/_smart_banner.html.slim
@@ -3,7 +3,7 @@
     .info
       i.icon-close
       a href="#{browser.platform.android? ? android_store_page : apple_store_page}"
-        = image_tag "icon", class: "app-icon"
+        = image_tag "icon.png", class: "app-icon"
       h3 Baixe o app da Mudamos
   javascript:
     $(".smart-banner").on("click", ".icon-close", function() {


### PR DESCRIPTION
This PR closes #211 

How was it before?

 - the smart banner's icon breaks on the heroku

What has changed?

- the image was fixed

What should I pay attention when reviewing this PR?

everthing

Is this PR dangerous?

no