### PR TITLE
Closing both login and registration forms during petition sign (Issue 215)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR #216]: Closing both login and registration forms during petition sign (Issue 215)
 * [PR #213]: New sign api with pre signature email (Issue 193, 206)
 * [PR #211]: Extension was missing on the smart banner icon (issue 212)
 * [PR #209]: Parsing a hexadecimal string representing the signature (Issue 208)

--- a/app/assets/javascripts/sign_petition.js
+++ b/app/assets/javascripts/sign_petition.js
@@ -23,7 +23,7 @@
       if (data.responseJSON.error == "user_cant_interact_with_plugin") {
         muRequireUserForm({
           fields: ["birthday"],
-          success: signPetition 
+          success: signPetition
         });
       } else {
         location.reload();
@@ -39,8 +39,8 @@
         signPetition();
       } else {
         document.open_login(function() {
-          $("#modal-session-new .icon-close").click();
-          signPetition();
+          $("#modal-session-new, #modal-registration-new").modal("hide");
+          signPetition()
         });
       }
     });


### PR DESCRIPTION
This PR closes #215.

### How was it before?

- during the petition sign, after the sign up, the modal would not close

### What has changed?

- now we properly close both the session and registration form

### What should I pay attention when reviewing this PR?

Nothing in particular.

### Is this PR dangerous?

No.