### PR TITLE
Remove Faraday net_http_persistent adapter (Issue 225)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR #226]: Remove Faraday net_http_persistent adapter (Issue 225)
 * [PR #223]: Add mobile api secret (Issue 219)
   - Set `MOBILE_API_SECRET`
 * [PR #220]: Add petition video (Issue 217)

--- a/app/services/mobile_api_service.rb
+++ b/app/services/mobile_api_service.rb
@@ -202,7 +202,7 @@ class MobileApiService
   def connection
     @connection ||= Faraday.new(:url => @url) do |connection|
       connection.response :logger, @logger
-      connection.adapter :net_http_persistent
+      connection.adapter Faraday.default_adapter
     end
   end
 end


### PR DESCRIPTION
This PR closes #225.

### How was it before?

- faraday used the `net_http_persistent` adapter. We were having too many erros with it. `too many connections reset`

### What has changed?

- now we're using faraday's default adapter. We don't have a strong reason to use a persistent connection.

### What should I pay attention when reviewing this PR?

Everything.

### Is this PR dangerous?

No.