### PR TITLE
Fetch petition past versions from the mobile api (Issue 222)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* [PR #227]: Fetch petition past versions from the mobile api (Issue 222)
+  - Configure crontab `rake petitions:past_versions` to every 10 minutes. This will update the cache.
 * [PR #226]: Remove Faraday net_http_persistent adapter (Issue 225)
 * [PR #223]: Add mobile api secret (Issue 219)
   - Set `MOBILE_API_SECRET`

--- a/app/assets/stylesheets/petition.sass
+++ b/app/assets/stylesheets/petition.sass
@@ -67,32 +67,6 @@
   .past-versions
     text-transform: uppercase
 
-  .past-versions-popover
-    li
-      clear: both
-      margin-top: 25px
-
-  .popover
-    background-color: #202020
-
-    &.right .arrow:after
-      border-right-color: #202020
-
-    .popover-content
-      font-size: 12px
-
-      .medium-padded
-        padding: 0px 46px
-
-        &:nth-child(2)
-          font-size: 16px
-
-        &:nth-child(3)
-          font-size: 10px
-
-      i
-        font-size: 35px
-
   .petition-body-title
     font-size: 36px
     margin-top: 98px
@@ -324,3 +298,30 @@
   .petition-signature
     label
       margin-right: 5px
+
+.petition-past-versions-list
+  li
+    clear: both
+    margin-top: 25px
+
+.petition-past-versions-popover
+  background-color: #202020
+
+  &.right .arrow:after
+    border-right-color: #202020
+
+  .popover-content
+    color: #fff
+    font-size: 12px
+
+    .medium-padded
+      padding: 0px 46px
+
+      &:nth-child(2)
+        font-size: 16px
+
+      &:nth-child(3)
+        font-size: 10px
+
+    i
+      font-size: 35px

--- a/app/jobs/petition_publisher_worker.rb
+++ b/app/jobs/petition_publisher_worker.rb
@@ -3,9 +3,14 @@ class PetitionPublisherWorker
   shoryuken_options queue: Rails.application.secrets.queues['petition_publisher'], auto_delete: true
 
   attr_reader :repository
+  attr_accessor :petition_service
 
-  def initialize(repository: PetitionPlugin::DetailVersionRepository.new)
+  def initialize(
+    repository: PetitionPlugin::DetailVersionRepository.new,
+    petition_service: PetitionService.new
+  )
     @repository = repository
+    @petition_service = petition_service
   end
 
   def perform(sqs_msg, body)
@@ -16,8 +21,21 @@ class PetitionPublisherWorker
     if version
       version.update! published: true
       Rails.logger.info "Version published #{petition_detail_version_id}"
+
+      refresh_caches version
     else
       Rails.logger.warn "Version not found #{petition_detail_version_id}"
     end
+  end
+
+  def refresh_caches(version)
+    Rails.logger.info("Refreshing caches")
+    past_versions(version.petition_plugin_detail_id)
+  end
+
+  def past_versions(id)
+    petition_service.fetch_past_versions id, fresh: true
+  rescue => e
+    Rails.logger.info("Error fetching petition past versions: #{e.message} #{e.backtrace.join(" | ")}")
   end
 end

--- a/app/services/mobile_api_service.rb
+++ b/app/services/mobile_api_service.rb
@@ -33,6 +33,35 @@ class MobileApiService
     @timeout = timeout
   end
 
+  PetitionVersion = Struct.new(
+    :version_id,
+    :version_name,
+    :updated_at,
+    :blockchain_timestamp,
+    :name,
+    :signature,
+    :page_url,
+    :pdf_url
+  )
+  def petition_versions(petition_id)
+    response = get("/api/v1/petition/plip/#{petition_id}/versions")
+
+    body = JSON.parse(response.body)["data"]["versions"] || []
+
+    body.each_with_index.map do |version, index|
+      PetitionVersion.new(
+        version["petition_version"],
+        body.length - index,
+        version["petition_updatedat"].present? ? Time.parse(version["petition_updatedat"]) : nil,
+        version["petition_blockstamp"].present? ? Time.parse(version["petition_blockstamp"]) : nil,
+        version["petition_name"],
+        version["petition_signature"],
+        version["petition_page_url"],
+        version["petition_pdf_url"],
+      )
+    end
+  end
+
   def register_petition_version(petition_detail_version)
     phase = petition_detail_version.petition_plugin_detail.plugin_relation.related
 

--- a/app/services/petition_service.rb
+++ b/app/services/petition_service.rb
@@ -46,4 +46,17 @@ class PetitionService
       mobile_service.petition_signatures(petition_id)
     end
   end
+
+  def fetch_past_versions(petition_id, fresh: false)
+    cache_key = "mobile_petition_past_versions:#{petition_id}"
+
+    Rails.cache.fetch(cache_key, force: fresh) do
+      begin
+        mobile_service.petition_versions(petition_id)
+      rescue => e
+        Rails.logger.info("Error fetching petition past versions: #{e.message} #{e.backtrace.join(" | ")}")
+        Array.new
+      end
+    end
+  end
 end

--- a/app/views/cycles/plugin_relations/petition.html.slim
+++ b/app/views/cycles/plugin_relations/petition.html.slim
@@ -63,25 +63,25 @@ section#petition-index
             .pull-left
               i.icon-text2 style="color: #{@cycle.color}"
             div.medium-padded
-              a.download-document href=@petition.published_version.document_url style="color: #{@cycle.color}" target="_blank"
-                strong Baixe o PDF
-              |  do projeto
+              - if petition_published_pdf_version
+                a.download-document href=petition_published_pdf_version.pdf_url style="color: #{@cycle.color}" target="_blank"
+                  strong Baixe o PDF
+                |  do projeto
             div.medium-padded
               small.last_version_date
-            - if @petition.past_versions.length > 0
+            - if petition_past_pdf_versions.length > 0
               div.medium-padded
                 a.past-versions href="javascript:void(0)" style="color: #{@cycle.color}" Veja versões anteriores
 
               script#past-versions-popover type="text/template"
                 ul.list-unstyled.past-versions-popover
-                  - past_versions_length = past_versions.length
-                  - past_versions.each_with_index do |version, index|
+                  - petition_past_pdf_versions.each do |version|
                     li
                       div.pull-left
                         i.icon-text2 style="color: #{@cycle.color}"
                       div.medium-padded
-                        a href="#{version.document_url}" style="color: #{@cycle.color}"  ="Versão #{ past_versions_length - index}"
-                      div.medium-padded= "Criada em #{version.created_at.strftime("%d/%m/%Y às %H:%M")}"
+                        a href="#{version.pdf_url}" style="color: #{@cycle.color}"  ="Versão #{version.version_name}"
+                      div.medium-padded= "Criada em #{version.updated_at.strftime("%d/%m/%Y às %H:%M")}"
 
         .row.phone-bottom-info
           - if @phase.in_progress?

--- a/app/views/cycles/plugin_relations/petition.html.slim
+++ b/app/views/cycles/plugin_relations/petition.html.slim
@@ -74,10 +74,16 @@ section#petition-index
               div.medium-padded
                 a.past-versions href="javascript:void(0)" style="color: #{@cycle.color}" Veja versões anteriores
 
+              script#popover_template type="text/template"
+                .petition-past-versions-popover.popover role="tooltip"
+                  .arrow
+                  h3.popover-title
+                  .popover-content
+
               script#past-versions-popover type="text/template"
-                ul.list-unstyled.past-versions-popover
+                ul.list-unstyled.petition-past-versions-list
                   - petition_past_pdf_versions.each do |version|
-                    li
+                    li.clearfix
                       div.pull-left
                         i.icon-text2 style="color: #{@cycle.color}"
                       div.medium-padded
@@ -161,7 +167,9 @@ javascript:
 
       $(".past-versions").popover({
         html: true,
+        container: "body",
         content: $("#past-versions-popover").html(),
+        template: $("#popover_template").html(),
         placement: "right",
       });
 

--- a/app/views/cycles/plugin_relations/petition.html.slim
+++ b/app/views/cycles/plugin_relations/petition.html.slim
@@ -68,7 +68,8 @@ section#petition-index
                   strong Baixe o PDF
                 |  do projeto
             div.medium-padded
-              small.last_version_date
+              - if petition_published_pdf_version && petition_published_pdf_version.blockchain_timestamp
+                small.last_version_date= "A versão atual for criada no dia #{petition_published_pdf_version.blockchain_timestamp.strftime("%d/%m/%Y às %H:%M")}"
             - if petition_past_pdf_versions.length > 0
               div.medium-padded
                 a.past-versions href="javascript:void(0)" style="color: #{@cycle.color}" Veja versões anteriores
@@ -81,7 +82,8 @@ section#petition-index
                         i.icon-text2 style="color: #{@cycle.color}"
                       div.medium-padded
                         a href="#{version.pdf_url}" style="color: #{@cycle.color}"  ="Versão #{version.version_name}"
-                      div.medium-padded= "Criada em #{version.updated_at.strftime("%d/%m/%Y às %H:%M")}"
+                      - if version.blockchain_timestamp
+                        div.medium-padded= "Criada em #{version.blockchain_timestamp.strftime("%d/%m/%Y às %H:%M")}"
 
         .row.phone-bottom-info
           - if @phase.in_progress?
@@ -168,12 +170,6 @@ javascript:
 
         apiClient.getPetitionInfo(#{@petition.id}).then(function(petitionInfo) {
           if (petitionInfo) {
-            if (petitionInfo.updated_at) {
-              $(".last_version_date").text("A versão atual for criada no dia " + moment(petitionInfo.updated_at).format("DD/MM/YYYY à\\s HH:mm"));
-            } else {
-              $(".last_version_date").text("");
-            }
-
             var count = petitionInfo.signatures_count;
 
             var percentage = (count / signaturesRequired) * 100;

--- a/lib/tasks/petitions.rake
+++ b/lib/tasks/petitions.rake
@@ -64,4 +64,32 @@ namespace :petitions do
       end
     end
   end
+
+  desc "Fetches petitions past versions from the api and store it on the cache"
+  task past_versions: :environment do |_, args|
+
+    log = -> message {
+      puts message
+      Rails.logger.info message
+    }
+
+    error = -> message {
+      puts message
+      Rails.logger.error message
+    }
+
+    petition_service = PetitionService.new
+
+    PetitionPlugin::Detail.all.find_in_batches do |batch|
+      batch.each do |detail|
+        begin
+          petition_service.fetch_past_versions detail.id, fresh: true
+          log.call "Fetched past versions for petition #{detail.id}"
+        rescue => error
+          error.call "Could not fetch past versions for petition #{detail.id}"
+          error.call error
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR closes #222.

### How was it before?

- the petition past versions was being rendered by looking into our own database

### What has changed?

- now we list the past versions using the mobile api
- there is persistent cache when fetching this info, therefore we must configure a rake task that will reprocess the information `rake petitions:past_versions`

### What should I pay attention when reviewing this PR?

Everything.

### Is this PR dangerous?

No.