### PR TITLE
Add new reset password modals (Issue 196)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR #236]: Add new reset password modals (Issue 196)
 * [PR #235]: Add new login design (Issue 196)
 * [PR #234]: Add new sign up design (Issue 196)
 * [PR #233]: New signatures pdf list design (Issue 200)

--- a/app/assets/javascripts/users/login.coffee
+++ b/app/assets/javascripts/users/login.coffee
@@ -25,13 +25,18 @@ document.open_forgot_password = (func = null) ->
 
 
 $ ->
-  $("#modal-session-new").on "click", ".login", (e) ->
+  $("#modal-session-new, #modal-passwords-new").on "click", ".login", (e) ->
     e.preventDefault()
     $("#modal-session-login").modal "show"
 
-  $("#modal-session-login").on "click", ".sign-up", (e) ->
+  $("#modal-session-login, #modal-passwords-new").on "click", ".sign-up", (e) ->
     e.preventDefault()
     $("#modal-session-new").modal "show"
+
+  $("#modal-session-login").on "click", ".forgot-password", (e) ->
+    e.preventDefault()
+    document.open_forgot_password()
+
 
 $ ->
   state_select = $('select#user_state')

--- a/app/assets/stylesheets/global.sass
+++ b/app/assets/stylesheets/global.sass
@@ -1572,7 +1572,16 @@ body.modal-open .body-container
     @media (min-width: $screen-sm-min)
       padding: 40px
 
+    form
+      ol
+        padding: 0
+        margin: 0
+
 .modal-footer
+  font-family: "Merriweather Sans"
+  font-size: 16px
+  line-height: 20px
+  color: #4D4D4D
   padding: 15px 16px 22px
   text-align: center
 
@@ -3144,11 +3153,6 @@ nav.navbar.navbar-default ul.dropdown-menu.cycle
       color: rgba(0,0,0,0.38)
       text-transform: uppercase
       margin-top: -10px
-
-#modal-session-new, #modal-session-login
-  ol
-    padding: 0
-    margin: 0
 
 #modal-session-login
   .forgot-password-container

--- a/app/views/users/passwords/edit.html.slim
+++ b/app/views/users/passwords/edit.html.slim
@@ -1,36 +1,9 @@
-.row
-  .col-xs-12.col-sm-6.col-sm-offset-3
-    .section-title Mudar sua senha
-.row
-  .col-xs-12.col-sm-6.col-sm-offset-3
-    = semantic_form_for @reset_password_user, as: :user, url: user_password_path, html: { autocomplete: :off, method: :put }, remote: true do |f|
+.modal-body
+  = semantic_form_for @reset_password_user, as: :user, url: user_password_path, html: { autocomplete: :off, method: :put, class: "row" }, remote: true do |f|
+    = f.inputs class: "col-xs-12"
       = f.hidden_field :reset_password_token
-      = input f, :password, as: :password, label: 'Nova Senha'
+      = input f, :password, as: :password, label: 'Nova Senha', wrapper_class: "first"
       = input f, :password_confirmation, as: :password, label: 'Confirmação de Nova Senha'
-      button type="submit"
-        .arrow
-        .background
-        | Alterar senha
 
-/ h2
-/   | Change your password
-/ = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
-/   = devise_error_messages!
-/   = f.hidden_field :reset_password_token
-/   .field
-/     = f.label :password, "New password"
-/     br
-/     - if @minimum_password_length
-/       em
-/         | (
-/         = @minimum_password_length
-/         |  characters minimum)
-/     br
-/     = f.password_field :password, autofocus: true, autocomplete: "off"
-/   .field
-/     = f.label :password_confirmation, "Confirm new password"
-/     br
-/     = f.password_field :password_confirmation, autocomplete: "off"
-/   .actions
-/     = f.submit "Change my password"
-/ = render "users/shared/links"
+    .col-xs-12
+      button.rounded-button.new type="submit" Alterar senha

--- a/app/views/users/passwords/new.html.slim
+++ b/app/views/users/passwords/new.html.slim
@@ -1,22 +1,14 @@
-.row
-  .col-xs-12.col-sm-6.col-sm-offset-3
-    .section-title Esqueceu sua senha?
-.row
-  .col-xs-12.col-sm-6.col-sm-offset-3
-    = semantic_form_for User.new, as: :user, url: user_password_path, html: { autocomplete: :off, method: :post }, remote: true do |f|
+.modal-body
+  = semantic_form_for User.new, as: :user, url: user_password_path, html: { autocomplete: :off, method: :post, class: "row" }, remote: true do |f|
+    = f.inputs class: "col-xs-12"
       = input f, :email, label: 'Email'
-      button type="submit"
-        .arrow
-        .background
-        | Enviar
-/ h2
-/   | Forgot your password?
-/ = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
-/   = devise_error_messages!
-/   .field
-/     = f.label :email
-/     br
-/     = f.email_field :email, autofocus: true
-/   .actions
-/     = f.submit "Send me reset password instructions"
-/ = render "users/shared/links"
+
+    .col-xs-12
+      button.rounded-button.new type="submit" Recuperar senha
+
+.modal-footer
+  .row
+    .col-xs-12
+      a.sign-up.light-link href="#" Crie uma conta
+      span<>ou
+      a.login.light-link href="#" faça login


### PR DESCRIPTION
This PR implements the new password recovery modals from #196.

### How was it before?

- there were the old modals

### What has changed?

- both reset password and change password modals now have a new design

### What should I pay attention when reviewing this PR?

Nothing in particular.

### Is this PR dangerous?

No.

![screenshot 2017-03-23 09 04 30](https://cloud.githubusercontent.com/assets/252061/24246916/3815f74c-0fa8-11e7-8b8f-cbabe6c8d108.png)
![screenshot 2017-03-23 09 04 45](https://cloud.githubusercontent.com/assets/252061/24246917/38161c7c-0fa8-11e7-9244-1d211447b795.png)
![screenshot 2017-03-23 09 04 53](https://cloud.githubusercontent.com/assets/252061/24246919/3817bfb4-0fa8-11e7-89bc-29664b4e6c75.png)
![screenshot 2017-03-23 09 05 05](https://cloud.githubusercontent.com/assets/252061/24246918/38174a20-0fa8-11e7-9df2-35e596dfb674.png)
