### PR TITLE
Add new home blocks (Issue 244)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR #245]: Add new home blocks (Issue 244)
 * [PR #239]: Improves the petition page layout (Issue 202)
 * [PR #238]: Issue 196 complete form (Issue 196)
 * [PR #236]: Add new reset password modals (Issue 196)

--- a/app/assets/javascripts/inputs/image_upload.coffee
+++ b/app/assets/javascripts/inputs/image_upload.coffee
@@ -1,37 +1,35 @@
-input = undefined
-button = undefined
-img_wrapper = undefined
 filename = undefined
 revert = undefined
 invertExifValues = ['right-top', 'left-bottom']
 imageOrientation = undefined
 
 $ ->
-  if $('form').find('input.image-upload[type="file"]').length > 0
-    input = $('form').find('input.image-upload[type="file"]')
+  $("form").each ->
+    if $(this).find('input.image-upload[type="file"]').length > 0
+      input = $(this).find('input.image-upload[type="file"]')
 
-    button = $('button.upload-image')
-    img_wrapper = $('.file-input-image')
+      button = $(this).find('button.upload-image')
+      img_wrapper = $(this).find('.file-input-image')
 
-    button.click (e) =>
-      e.preventDefault()
-      input.click (e) =>
-        e.stopPropagation()
-      input.click()
+      button.click (e) =>
+        e.preventDefault()
+        input.click (e) =>
+          e.stopPropagation()
+        input.click()
 
 
-    input.change (e) =>
-      file = e.target.files[0]
+      input.change (e) =>
+        file = e.target.files[0]
 
-      if file
-        reader = new FileReader()
-        reader.onload = ->
-          img_wrapper
-            .removeClass("default")
-            .css("background-image": "none")
-            .css("background-image": "url('#{reader.result}')")
+        if file
+          reader = new FileReader()
+          reader.onload = ->
+            img_wrapper
+              .removeClass("default")
+              .css("background-image": "none")
+              .css("background-image": "url('#{reader.result}')")
 
-        reader.readAsDataURL file
+          reader.readAsDataURL file
 
 
 getAndTruncateFilenameFromFileInput = (fullPath) ->

--- a/app/assets/stylesheets/admin/global.sass
+++ b/app/assets/stylesheets/admin/global.sass
@@ -1706,3 +1706,15 @@ form
     // margin-top: 10px
     position: fixed
     opacity: 1
+
+.file-input-image.setting-icon
+  background-size: contain
+  background-position: center
+
+.margin-vertical
+  margin-top: 20px
+  margin-bottom: 20px
+
+.margin-horizontal
+  margin-left: 20px
+  margin-right: 20px

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -31,8 +31,6 @@ class Setting < ActiveRecord::Base
 
   validates_attachment :picture, :content_type => { :content_type => ["image/jpeg", "image/gif", "image/png", "image/jpg", "image/svg+xml", "application/pdf"] }
 
-  validate :value_or_picture
-
   def all_attributes
     keys = super - [
       "picture_file_size",
@@ -51,10 +49,6 @@ class Setting < ActiveRecord::Base
   end
 
   private
-
-  def value_or_picture
-    errors.add(:base, 'Choose a value or picture for this setting') unless (value? || picture?)
-  end
 
   def forbid_svg
     if self.picture_content_type.include? "image/"

--- a/app/repositories/home_block_repository.rb
+++ b/app/repositories/home_block_repository.rb
@@ -1,0 +1,63 @@
+class HomeBlockRepository
+  Block = Struct.new(:title, :body, :picture) do
+    def blank?
+      title.blank? && body.blank? && picture.blank?
+    end
+
+    def present?
+      !blank?
+    end
+  end
+
+  HomeBlock = Struct.new(
+    :what_is,
+    :solution,
+    :tools,
+    :mobilization
+  )
+
+  def blocks
+    HomeBlock.new(
+      what_is,
+      solution,
+      tools,
+      mobilization
+    )
+  end
+
+  def what_is
+    Block.new(
+      Setting.find_by_key("home_block_1_title").try(:value),
+      Setting.find_by_key("home_block_1_body").try(:value),
+      Setting.find_by_key("home_block_1_icon").try(:picture)
+    )
+  end
+
+  def solution
+    Block.new(
+      Setting.find_by_key("home_block_2_title").try(:value),
+      Setting.find_by_key("home_block_2_body").try(:value),
+      Setting.find_by_key("home_block_2_icon").try(:picture)
+    )
+  end
+
+  def tools
+    blocks = (3..7).each.map do |index|
+      Block.new(
+        Setting.find_by_key("home_block_#{index}_title").try(:value),
+        Setting.find_by_key("home_block_#{index}_body").try(:value),
+        Setting.find_by_key("home_block_#{index}_icon").try(:picture)
+      )
+    end
+
+    blocks.reject(&:blank?)
+  end
+
+  def mobilization
+    Block.new(
+      Setting.find_by_key("home_block_8_title").try(:value),
+      Setting.find_by_key("home_block_8_body").try(:value),
+      Setting.find_by_key("home_block_8_icon").try(:picture)
+    )
+  end
+end

--- a/app/views/admin/settings/index.html.slim
+++ b/app/views/admin/settings/index.html.slim
@@ -70,6 +70,49 @@
               = f.submit 'Salvar', class: "btn"
 
 .row
+  .col-xs-12
+    .title
+      h2 Blocos
+    .row
+      .col-xs-12
+        .card-module
+          p style="margin: 0"
+            b Novos blocos da home
+
+- (1..8).each do |i|
+  .row.row-same-height.margin-vertical
+    .col-xs-8.col-xs-height.col-top
+      .card-background
+      .setting-static-content
+        .row
+          .col-xs-12.setting-title
+            button.edit-setting-button
+              i.icon-edit
+            = Setting.find_by_key("home_block_#{i}_title").value.try :html_safe
+        .row
+          .col-xs-12.setting-content
+            = Setting.find_by_key("home_block_#{i}_body").value.try :html_safe
+      .setting-form
+        .row
+          .col-xs-12
+            = semantic_form_for [:admin, Setting.find_by_key("home_block_#{i}_title")] do |f|
+              = f.input :value, label: false, as: :string
+              = f.submit 'Salvar', class: "btn"
+        .row
+          .col-xs-12
+            = semantic_form_for [:admin, Setting.find_by_key("home_block_#{i}_body")] do |f|
+              = f.input :value, label: false, input_html: { class: "setting-tinymce" }
+              = f.submit 'Salvar', class: "btn"
+    .col-xs-4.col-xs-height
+      = semantic_form_for [:admin, Setting.find_by_key("home_block_#{i}_icon")], html: { class: 'image-form' } do |f|
+        = f.input :picture, as: :file, label: false, input_html: { class: 'image-upload' }
+        .file-input-image.setting-icon style="background-image: url('#{Setting.find_by_key("home_block_#{i}_icon").picture.url(:original)}')"
+        = f.submit 'Salvar', class: "btn pull-right"
+        button.upload-image
+          .background
+          | Atualizar Imagem
+
+.row
   / .col-xs-4
   /   .title
   /     h2 Críticas e Sugestões

--- a/app/views/admin/settings/index.html.slim
+++ b/app/views/admin/settings/index.html.slim
@@ -18,7 +18,7 @@
             i.icon-edit
       .row
         .col-xs-12.setting-content
-          = Setting.find_by_key('home_sub_title').value.html_safe
+          = Setting.find_by_key('home_sub_title').value.try :html_safe
     .setting-form
       .row
         .col-xs-12
@@ -53,10 +53,10 @@
           .col-xs-12.setting-title
             button.edit-setting-button
               i.icon-edit
-            = Setting.find_by_key("home_title#{i}").value.html_safe
+            = Setting.find_by_key("home_title#{i}").value.try :html_safe
         .row
           .col-xs-12.setting-content
-            = Setting.find_by_key("home_text#{i}").value.html_safe
+            = Setting.find_by_key("home_text#{i}").value.try :html_safe
       .setting-form
         .row
           .col-xs-12

--- a/lib/tasks/settings.rake
+++ b/lib/tasks/settings.rake
@@ -1,0 +1,118 @@
+namespace :settings do
+  desc "Adds the new home blocks"
+  task add_new_home_blocks: :environment do
+    values = [
+      {
+        key: "home_block_1_title"
+      },
+      {
+        key: "home_block_1_body",
+        value: "<p><strong>Mudamos</strong> é uma caixa de ferramentas para você entender, participar e construir soluções de forma democrática na Internet.</p>"
+      },
+      {
+        key: "home_block_1_icon",
+        picture: "https://s3-sa-east-1.amazonaws.com/mudamos-images/images/home-block-phone.svg"
+      },
+      {
+        key: "home_block_2_title",
+        value: "Cada desafio público precisa de uma solução diferente"
+      },
+      {
+        key: "home_block_2_body",
+        value: "<p>É por isso que Mudamos reúne várias ferramentas de participação, que também podem ser usadas em conjunto</p>"
+      },
+      {
+        key: "home_block_2_icon",
+        picture: "https://s3-sa-east-1.amazonaws.com/mudamos-images/images/home-block-puzzle.svg"
+      },
+      {
+        key: "home_block_3_title",
+        value: "Priorize ideias"
+      },
+      {
+        key: "home_block_3_body",
+        value: "<p>Prorize ideias mais importantes.</p>"
+      },
+      {
+        key: "home_block_3_icon",
+        picture: "https://s3-sa-east-1.amazonaws.com/mudamos-images/images/home-block-priorize.svg"
+      },
+      {
+        key: "home_block_4_title",
+        value: "Discuta"
+      },
+      {
+        key: "home_block_4_body",
+        value: "<p>Debata questões, concorde e discorde de opiniões e produza debates informados.</p>"
+      },
+      {
+        key: "home_block_4_icon",
+        picture: "https://s3-sa-east-1.amazonaws.com/mudamos-images/images/home-block-discuta.svg"
+      },
+      {
+        key: "home_block_5_title",
+        value: "Assine"
+      },
+      {
+        key: "home_block_5_body",
+        value: "<p>Dê seu apoio a projetos de lei de iniciativa popular de forma eletrônica.</p>"
+      },
+      {
+        key: "home_block_5_icon",
+        picture: "https://s3-sa-east-1.amazonaws.com/mudamos-images/images/home-block-assine.svg"
+      },
+      {
+        key: "home_block_6_title",
+        value: "Entenda"
+      },
+      {
+        key: "home_block_6_body",
+        value: "<p>Use nosso glossário para participar de maneira informada.</p>"
+      },
+      {
+        key: "home_block_6_icon",
+        picture: "https://s3-sa-east-1.amazonaws.com/mudamos-images/images/home-block-entenda.svg"
+      },
+      {
+        key: "home_block_7_title",
+        value: "Acompanhe"
+      },
+      {
+        key: "home_block_7_body",
+        value: "<p>Lei os relatórios produzidos sobre os ciclos de mobilização.</p>"
+      },
+      {
+        key: "home_block_7_icon",
+        picture: "https://s3-sa-east-1.amazonaws.com/mudamos-images/images/home-block-acompanhe.svg"
+      },
+      {
+        key: "home_block_8_title",
+        value: "Mudamos funciona em ciclos de mobilização"
+      },
+      {
+        key: "home_block_8_body",
+        value: "<p>Cada ciclo tem seus próprios objetivos e usa diferentes <strong>conjuntos de ferramentas</strong> para atingi-los, buscando o maior <strong>impacto positivo</strong> possível de <strong>forma legítima</strong>. Os ciclos são compostos por diferentes fases definidas a priori de acordo com os objetivos de cada ciclo. Cada fase utiliza uma ferramenta para seu desenvolvimento.</p>"
+      },
+      {
+        key: "home_block_8_icon",
+        picture: "https://s3-sa-east-1.amazonaws.com/mudamos-images/images/home-block-arrows.svg"
+      }
+    ]
+
+    values.each do |attributes|
+      Setting.find_or_initialize_by(key: attributes[:key]) do |setting|
+        setting.attributes = attributes
+        setting.save!
+      end
+    end
+  end
+
+  desc "Destroys all home blocks"
+  task remove_new_home_blocks: :environment do
+    (1..8).each do |index|
+      Setting.find_by_key("home_block_#{index}_title").really_destroy!
+      Setting.find_by_key("home_block_#{index}_body").really_destroy!
+      Setting.find_by_key("home_block_#{index}_icon").really_destroy!
+    end
+  end
+end


### PR DESCRIPTION
This PR closes #244.

### how was it before?

- there is a new home design which requires us to add new `Setting`s

### What has changed?

- these settings are the new home blocks
- added 8 of them
- `home_block_{index}_(title|body|icon)`
- the setting model does not validate the value or image presence
- added new rake task to preload these new blocks
- added new rake task to remove these new blocks
- the image upload script now handles multiple forms

### What should I pay attention when reviewing this PR?

Does it make sense?

### Is this PR dangerous?

No.

![mar-27-2017 13-49-07](https://cloud.githubusercontent.com/assets/252061/24368084/8312ffba-12f5-11e7-9eac-4c0344618f3b.gif)

