### PR TITLE
Add tools block mock design (Issue 242)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next
 
+* [PR #247]: Add tools block mock design (Issue 242)
 * [PR #245]: Add new home blocks (Issue 244)
+  - Run `rake settings:add_new_home_blocks`
 * [PR #239]: Improves the petition page layout (Issue 202)
 * [PR #238]: Issue 196 complete form (Issue 196)
 * [PR #236]: Add new reset password modals (Issue 196)

--- a/app/assets/javascripts/application.coffee
+++ b/app/assets/javascripts/application.coffee
@@ -64,6 +64,7 @@
 #= require mu.require-user-form
 #= require moment.min
 #= require asmcrypto
+#= require home-blocks
 
 document.expiration_default_time = 300
 

--- a/app/assets/javascripts/home-blocks.js
+++ b/app/assets/javascripts/home-blocks.js
@@ -1,0 +1,31 @@
+(function($) {
+  "use strict";
+
+  function homeTools() {
+    var $section = $(".home-block-tools.carousel");
+
+    function hideAll() {
+      $section.find(".display .tool, .display .block-body").hide();
+    }
+
+    function toggleTool() {
+      var $tool = $(this);
+      var index = $tool.parent().children().index($tool);
+
+      hideAll();
+
+      $($section.find(".display .tool")[index]).show();
+      $($section.find(".display .block-body")[index]).show();
+    }
+
+    hideAll();
+    $section.on("mouseover", ".options .tool", toggleTool);
+
+    // Init first tool
+    $section.find(".options .tool:first").trigger("mouseover");
+  }
+
+  $(document).ready(function() {
+    homeTools();
+  });
+})(jQuery);

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -18,5 +18,6 @@
  *= require signature
  *= require simple_navbar
  *= require global
+ *= require home-blocks
  *= require_self
  */

--- a/app/assets/stylesheets/home-blocks.sass
+++ b/app/assets/stylesheets/home-blocks.sass
@@ -1,8 +1,10 @@
+@import "bourbon"
 @import "bootstrap/variables"
 @import "custom_variables"
 
 
 .home-block-tools
+  padding: 30px
   background-color: purple
   font-family: $font-family-serif
   color: white
@@ -14,12 +16,19 @@
     > .col-xs-height
       vertical-align: middle
 
+  .options
+    .block-icon:hover
+      &.medium
+        width: 70px
+        height: 70px
+
   .block-icon
     background-size: contain
     background-position: center
     background-repeat: no-repeat
     width: 120px
     height: 120px
+    +transition(all 0.3s ease)
 
     &.medium
       width: 60px

--- a/app/assets/stylesheets/home-blocks.sass
+++ b/app/assets/stylesheets/home-blocks.sass
@@ -1,0 +1,42 @@
+@import "bootstrap/variables"
+@import "custom_variables"
+
+
+.home-block-tools
+  background-color: purple
+  font-family: $font-family-serif
+  color: white
+
+  &.tool-even
+    background-color: black
+
+  .display
+    > .col-xs-height
+      vertical-align: middle
+
+  .options
+    > .tool
+
+
+  .block-icon
+    background-size: contain
+    background-position: center
+    background-repeat: no-repeat
+    width: 120px
+    height: 120px
+
+    &.medium
+      width: 60px
+      height: 60px
+
+  .tool
+    cursor: pointer
+    text-align: center
+
+    i
+      display: block
+      margin: 0 auto
+
+    span
+      margin-top: 15px
+      display: inline-block

--- a/app/assets/stylesheets/home-blocks.sass
+++ b/app/assets/stylesheets/home-blocks.sass
@@ -14,10 +14,6 @@
     > .col-xs-height
       vertical-align: middle
 
-  .options
-    > .tool
-
-
   .block-icon
     background-size: contain
     background-position: center

--- a/app/controllers/cycles_controller.rb
+++ b/app/controllers/cycles_controller.rb
@@ -1,4 +1,10 @@
 class CyclesController < ApplicationController
+  before_action :home_blocks, only: %i(index)
+
+  def home_block_repository
+    @home_block_repository ||= HomeBlockRepository.new
+  end
+
   def index
     @highlights = GridHighlight.order('id ASC').all
   end
@@ -6,4 +12,9 @@ class CyclesController < ApplicationController
   def show
     @cycle = Cycle.find params[:id]
   end
+
+  def home_blocks
+    @home_blocks ||= home_block_repository.blocks
+  end
+  helper_method :home_blocks
 end

--- a/app/views/cycles/index.html.slim
+++ b/app/views/cycles/index.html.slim
@@ -65,11 +65,42 @@ section.container-fluid#about
               h3 class=('text-right' if i%2 == 0) = Setting.find_by_key("home_title#{i}").value.html_safe
               = Setting.find_by_key("home_text#{i}").value.html_safe
 
+section.container-fluid.visible-md-block.visible-lg-block.home-block-tools.carousel
+  .container
+    .row.row-same-height.display
+      .col-xs-height.col-md-4
+        - home_blocks.tools.each do |tool|
+          .tool
+            i.block-icon style="background-image: url('#{tool.picture.url :original}')"
+            span.block-title = tool.title
+      .col-xs-height.col-md-8
+        - home_blocks.tools.each do |tool|
+          .block-body = tool.body.try :html_safe
+    .row.options
+      - tools_size = home_blocks.tools.size
+      - offset = (12 - (tools_size * 2)) / 2
+      - home_blocks.tools.each_with_index do |tool, index|
+        .col-xs-2.tool class="#{index == 0 ? "col-xs-offset-#{offset}" : nil}"
+          i.block-icon.medium style="background-image: url('#{tool.picture.url :original}')"
+          span.block-title = tool.title
+
+- home_blocks.tools.each_with_index do |tool, index|
+  section.container-fluid.visible-xs-block.visible-sm-block.home-block-tools class="#{cycle "tool-odd", "tool-even"}"
+    .container
+      .row
+        .col-xs-12.tool
+          i.block-icon style="background-image: url('#{tool.picture.url :original}')"
+          span.block-title = tool.title
+      .row
+        .col-xs-12
+          .block-body.text-center = tool.body.try :html_safe
+
+
 section.container-fluid#cycles
   .container
     .row
       .col-xs-12
-        h2.section-title Ciclos 
+        h2.section-title Ciclos
     .row
 
       - @cycles.each do |c|


### PR DESCRIPTION
This PR partially implements #242.

### How was it before?

- the tools home block was not present on the site home page

### What has changed?

- the new blocks are being loaded
- the tools block is displayed and when a desktop, mouse over triggers a display change
- when mobile and tablets, all tools are displayed

### What should I pay attention when reviewing this PR?

This PR does not implement the full layout, because it would be a double effort. We have this on a different branch now, and will apply the full design later.


### Is this PR dangerous?

No.