### PR TITLE
Add petition pdf signatures rake which will refresh the cache (Issue 228)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* [PR #259]: Add petition pdf signatures rake which will refresh the cache (Issue 228)
+  - Configure crontab `rake petitions:fetch_petition_pdf_signatures` to every 10 minutes. This will update the cache.
 * [PR #258]: Changes the static page layout (Issue 257)
 
 ## [1.6.1] - 28/03/2017

--- a/lib/tasks/petitions.rake
+++ b/lib/tasks/petitions.rake
@@ -91,7 +91,7 @@ namespace :petitions do
     end
   end
 
-  desc "Fetches petitions petitions pdf signatures and update the cache"
+  desc "Fetches petitions pdf signatures and update the cache"
   task fetch_petition_pdf_signatures: :environment do
     log = -> message {
       puts message

--- a/lib/tasks/petitions.rake
+++ b/lib/tasks/petitions.rake
@@ -29,9 +29,9 @@ namespace :petitions do
         begin
           petition_service.fetch_petition_info detail.id, fresh: true
           log.call "Fetched information for petition #{detail.id}"
-        rescue => error
+        rescue => e
           error.call "Could not fetch information for petition #{detail.id}"
-          error.call error
+          error.call e
         end
       end
     end
@@ -39,7 +39,6 @@ namespace :petitions do
 
   desc "Fetches petitions signers from the api and store it on the cache"
   task :fetch_signers, [:size] => :environment do |_, args|
-
     log = -> message {
       puts message
       Rails.logger.info message
@@ -57,17 +56,16 @@ namespace :petitions do
         begin
           petition_service.fetch_petition_signers detail.id, args[:size], fresh: true
           log.call "Fetched signers for petition #{detail.id}"
-        rescue => error
+        rescue => e
           error.call "Could not fetch signers for petition #{detail.id}"
-          error.call error
+          error.call e
         end
       end
     end
   end
 
   desc "Fetches petitions past versions from the api and store it on the cache"
-  task past_versions: :environment do |_, args|
-
+  task past_versions: :environment do
     log = -> message {
       puts message
       Rails.logger.info message
@@ -85,9 +83,36 @@ namespace :petitions do
         begin
           petition_service.fetch_past_versions detail.id, fresh: true
           log.call "Fetched past versions for petition #{detail.id}"
-        rescue => error
+        rescue => e
           error.call "Could not fetch past versions for petition #{detail.id}"
-          error.call error
+          error.call e
+        end
+      end
+    end
+  end
+
+  desc "Fetches petitions petitions pdf signatures and update the cache"
+  task fetch_petition_pdf_signatures: :environment do
+    log = -> message {
+      puts message
+      Rails.logger.info message
+    }
+
+    error = -> message {
+      puts message
+      Rails.logger.error message
+    }
+
+    petition_service = PetitionService.new
+
+    PetitionPlugin::Detail.all.find_in_batches do |batch|
+      batch.each do |detail|
+        begin
+          petition_service.fetch_petition_signatures detail.id, fresh: true
+          log.call "Fetched pdf signatures for petition #{detail.id}"
+        rescue => e
+          error.call "Could not fetch pdf signatures for petition #{detail.id}"
+          error.call e
         end
       end
     end


### PR DESCRIPTION
This PR closes #228.

### How was it before?

- there was no way to refresh the pdf signatures cache list

### What has changed?

- add new `rake petitions:fetch_petition_pdf_signatures`.

### What should I pay attention when reviewing this PR?

The rake.

### Is this PR dangerous?

No.