### PR TITLE
Header assets now have the full viewport height (Issue 267)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR #272]: Header assets now have the full viewport height (Issue 267)
 * [PR #271]: Improves the homepage layout
 * [PR #263]: Add lead logo settings (Issue 263)
   - Run `rake settings:add_home_lead_logo`

--- a/app/assets/stylesheets/cycle/index.css.sass
+++ b/app/assets/stylesheets/cycle/index.css.sass
@@ -16,7 +16,7 @@ body
     background-color: #fff
     overflow: hidden
     position: relative
-    height: 300px
+    height: 100vh
 
     h1
       font-family: $nunito-font


### PR DESCRIPTION
This PR closes #267.

Short description, see the image below:

![screenshot 2017-03-30 18 11 37](https://cloud.githubusercontent.com/assets/252061/24526454/98ccd002-1574-11e7-8f36-844031d8102b.png)
