### PR TITLE
Adjust scroll anchor on home page (Issue 268)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR #273]: Adjust scroll anchor on home page (Issue 268)
 * [PR #272]: Header assets now have the full viewport height (Issue 267)
 * [PR #271]: Improves the homepage layout
 * [PR #263]: Add lead logo settings (Issue 263)

--- a/app/assets/javascripts/base_header_scroll_to.coffee
+++ b/app/assets/javascripts/base_header_scroll_to.coffee
@@ -6,4 +6,5 @@ $ ->
 
     elem = $($(this).attr('scroll-to'))
 
-    $.scrollTo(elem, 1000)
+    headerHeight = $(".base-navbar").height()
+    $.scrollTo(elem, 1000, { offset: -headerHeight })

--- a/app/views/cycles/index.html.slim
+++ b/app/views/cycles/index.html.slim
@@ -44,7 +44,7 @@
               h2 = home_blocks.solution.title.html_safe
             = home_blocks.solution.body.try :html_safe
 
-  section.row.home-block-tools.carousel.block.purple.visible-md-block.visible-lg-block
+  section#tools_carousel.row.home-block-tools.carousel.block.purple.visible-md-block.visible-lg-block
     .col-xs-offset-2.col-xs-8
       .row.row-md-same-height
         .col-xs-5.col-md-height.col-middle.drawing.display
@@ -66,7 +66,7 @@
             h3.block-title = tool.title
 
   - home_blocks.tools.each_with_index do |tool, index|
-    section.row.visible-xs-block.visible-sm-block.home-block-tools.block class="#{cycle "purple", nil}"
+    section.row.visible-xs-block.visible-sm-block.home-block-tools.block id="#{index.zero? ? "tools_no_carousel" : nil}" class="#{cycle "purple", nil}"
       .col-xs-12.drawing.tool
         .light-wrapper: i.icon style="background-image: url('#{tool.picture.url :original}')"
       .col-sm-offset-2.col-sm-8.col-xs-12.content

--- a/app/views/layouts/shared/_base_header.html.slim
+++ b/app/views/layouts/shared/_base_header.html.slim
@@ -22,10 +22,12 @@
         ul.nav.navbar-nav.navbar-center.non-cycle
           - if params[:controller] == 'cycles' and params[:action] == 'index'
             li= link_to 'Sobre', '#', :'scroll-to' => '#about'
-            li= link_to 'Ferramentas', '#', :'scroll-to' => '#contribute'
+            li.visible-md-inline-block.visible-lg-inline-block= link_to 'Ferramentas', '#', :'scroll-to' => '#tools_carousel'
+            li.visible-xs-inline-block.visible-sm-inline-block= link_to 'Ferramentas', '#', :'scroll-to' => '#tools_no_carousel'
           - else
             li= link_to 'Sobre', root_path + '#about'
-            li= link_to 'Ferramentas', root_path + '#contribute'
+            li.visible-md-inline-block.visible-lg-inline-block= link_to 'Ferramentas', root_path + '#tools_carousel'
+            li.visible-xs-inline-block.visible-sm-inline-block= link_to 'Ferramentas', root_path + '#tools_no_carousel'
           li.dropdown class=("dropup" if params[:controller] == 'cycles' and params[:action] == 'index')
             = link_to '#', class: 'dropdown-toggle', data: { toggle: 'dropdown' }, aria: { haspopup: 'true', expanded: 'false' }, role: 'button' do
               | Ciclos


### PR DESCRIPTION
This PR closes #268.

### How was it before?

- the scroll to anchor  was not considering the header height

### What has changed?

- now it does
- the "Ferramentas" link now scrolls to the 3rd block (tools)