### PR TITLE
Fix scroll to after stick menu (Issue 275)

### DIFF
--- a/app/assets/javascripts/base_header_scroll_to.coffee
+++ b/app/assets/javascripts/base_header_scroll_to.coffee
@@ -6,5 +6,6 @@ $ ->
 
     elem = $($(this).attr('scroll-to'))
 
-    headerHeight = $(".base-navbar").height()
-    $.scrollTo(elem, 1000, { offset: -headerHeight })
+    $navBar = $(".base-navbar")
+    headerHeight = if $navBar.hasClass("stuck") then -$navBar.height() else 20
+    $.scrollTo(elem, 1000, { offset: headerHeight })


### PR DESCRIPTION
Closes #275.

Scrool to on home page was broken again after rolling back the stick menu.