### PR TITLE
Add “scroll to” functionality to the home blocks (Issue 270)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* [PR #282]: Add “scroll to” functionality to the home blocks (Issue 270)
+
 ## [1.8.0] - 30/03/2017
 
 * [PR #273]: Adjust scroll anchor on home page (Issue 268)

--- a/app/assets/images/arrow_down_purple.svg
+++ b/app/assets/images/arrow_down_purple.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="136px" height="62px" viewBox="0 0 136 62" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 42 (36781) - http://www.bohemiancoding.com/sketch -->
+    <title>purple_arrow_down</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <linearGradient x1="0%" y1="50%" x2="100%" y2="50%" id="linearGradient-1">
+            <stop stop-color="#211147" stop-opacity="0.85" offset="0%"></stop>
+            <stop stop-color="#513393" stop-opacity="0.85" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Artboard" transform="translate(-329.000000, -1132.000000)" fill="url(#linearGradient-1)">
+            <polygon id="purple_arrow_down" points="460.350006 1132 464.625 1136.93164 396.809998 1193.375 329 1136.93164 333.270004 1132 396.809998 1184.51172"></polygon>
+        </g>
+    </g>
+</svg>

--- a/app/assets/images/arrow_down_white.svg
+++ b/app/assets/images/arrow_down_white.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="136px" height="63px" viewBox="0 0 136 63" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 42 (36781) - http://www.bohemiancoding.com/sketch -->
+    <title>arrow_down</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Artboard" transform="translate(-146.000000, -1131.000000)" fill="#FFFFFF">
+            <polygon id="arrow_down" points="277.350006 1131.9375 281.625 1136.86914 213.809998 1193.3125 146 1136.86914 150.270004 1131.9375 213.809998 1184.44922"></polygon>
+        </g>
+    </g>
+</svg>

--- a/app/assets/javascripts/home-blocks.js
+++ b/app/assets/javascripts/home-blocks.js
@@ -33,7 +33,28 @@
     $section.find(".options .tool:first").trigger("mouseover");
   }
 
+  function blockScrollTo() {
+    $(".block-scroll-to").each(function() {
+      var $link = $(this);
+      var $block = $link.closest("section");
+
+      // Removes link if there is not next section
+      if ($block.nextAll("section:visible").length == 0) {
+        $link.remove();
+      }
+    }).on("click", function(e) {
+      e.preventDefault();
+
+      var $nextBlock = $(this).closest("section").nextAll("section:visible").get(0);
+      var $navBar = $(".base-navbar");
+      var headerHeight = $navBar.hasClass("stuck") ? -$navBar.height() : 20;
+
+      $.scrollTo($nextBlock, 1000, { offset: headerHeight });
+    });
+  }
+
   $(document).ready(function() {
     homeTools();
+    blockScrollTo();
   });
 })(jQuery);

--- a/app/assets/stylesheets/cycle/index.css.sass
+++ b/app/assets/stylesheets/cycle/index.css.sass
@@ -73,6 +73,22 @@ body
     padding: 75px 0
     font-size: 24px
 
+    .next
+      position: absolute
+      bottom: -50px
+      left: calc(50% - 20px)
+      text-align: center
+
+      a
+        text-decoration: none
+
+        &:hover, &:active
+          text-decoration: none
+
+        img
+          width: 40px
+          height: 40px
+
     &:first-of-type
       margin-top: 0
 
@@ -85,6 +101,10 @@ body
       background: linear-gradient(90deg, rgba(33, 17, 71, 0.85) 0, rgba(81, 51, 147, 0.85) 100%), image-url("textured_paper.png"), #e3e3e3
       color: #eeede9
 
+      .next
+        img.purple
+          display: none
+
     &:not(.purple)
       .light-wrapper
         border-radius: 230px
@@ -96,6 +116,10 @@ body
         .icon
           width: 100%
           height: 100%
+
+      .next
+        img.white
+          display: none
 
     &.carousel
       .drawing
@@ -236,6 +260,9 @@ body
       text-align: center
       font-size: 21px
 
+      .next
+        bottom: -40px
+
       &:not(.purple)
         .drawing
           .light-wrapper
@@ -266,9 +293,12 @@ body
 
   @media (max-width: $screen-xs-max)
     .block
-      padding: 30px 22px
+      padding: 30px 22px 40px
       text-align: center
       font-size: 16px
+
+      .next
+        bottom: -35px
 
       &:not(.purple)
         .drawing

--- a/app/helpers/cycle_helper.rb
+++ b/app/helpers/cycle_helper.rb
@@ -2,4 +2,13 @@ module CycleHelper
   def cycle_background(cycle_color)
     "#{cycle_color} linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, rgba(0, 0, 0, 0.14) 100%)"
   end
+
+  def next_block_link
+    content_tag :div, class: "next" do
+      content_tag :a, href: "#", class: "block-scroll-to" do
+        concat image_tag("arrow_down_white.svg", class: "white")
+        concat image_tag("arrow_down_purple.svg", class: "purple")
+      end
+    end
+  end
 end

--- a/app/views/cycles/index.html.slim
+++ b/app/views/cycles/index.html.slim
@@ -31,6 +31,8 @@
                 h2 = home_blocks.what_is.title.html_safe
               = home_blocks.what_is.body.try :html_safe
 
+          = next_block_link
+
     - if home_blocks.solution.present?
       section#contribute.row.block.solution class="#{ home_blocks.solution.title.blank? && "no-title" }"
         .col-sm-12.hidden-md.hidden-lg
@@ -46,6 +48,8 @@
               - if home_blocks.solution.title.present?
                 h2 = home_blocks.solution.title.html_safe
               = home_blocks.solution.body.try :html_safe
+
+          = next_block_link
 
     section#tools_carousel.row.home-block-tools.carousel.block.purple.visible-md-block.visible-lg-block
       .col-xs-offset-2.col-xs-8
@@ -68,6 +72,8 @@
                 i.icon.block-icon.medium style="background-image: url('#{tool.picture.url :original}')"
               h3.block-title = tool.title
 
+        = next_block_link
+
     - home_blocks.tools.each_with_index do |tool, index|
       section.row.visible-xs-block.visible-sm-block.home-block-tools.block id="#{index.zero? ? "tools_no_carousel" : nil}" class="#{cycle "purple", nil}"
         .col-xs-12.drawing.tool
@@ -75,6 +81,8 @@
         .col-sm-offset-2.col-sm-8.col-xs-12.content
           h2 = tool.title
           .block-body= tool.body.try :html_safe
+
+          = next_block_link
 
     - if home_blocks.mobilization.present?
       section#cycles.row.block.mobilization class="#{ home_blocks.mobilization.title.blank? && "no-title" }"


### PR DESCRIPTION
This PR closes #270.

### How was it before?

- the home blocks had no "scroll to" anchor

### What has changed?

- added anchor that scrolls to the next visible anchor

### What should I pay attention when reviewing this PR?

Scroll to feature.

### Is this PR dangerous?

No.

![mar-31-2017 11-49-12](https://cloud.githubusercontent.com/assets/252061/24555734/8e52e12c-1608-11e7-90e6-f0ad9dc0d410.gif)


![mar-31-2017 11-54-54](https://cloud.githubusercontent.com/assets/252061/24555840/ea883c26-1608-11e7-9ca8-f9214b6887ba.gif)
