### PR TITLE
Fix report broken link (Issue 252)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR #284]: Fix report broken link (Issue 252)
 * [PR #283]: Center cycle home description when single phased (Issue 218)
 * [PR #282]: Add “scroll to” functionality to the home blocks (Issue 270)
 

--- a/app/views/cycles/plugin_relations/compilation.html.slim
+++ b/app/views/cycles/plugin_relations/compilation.html.slim
@@ -4,14 +4,15 @@
       h1.section-title style="border-color: #{@cycle.color};" Relatoria
 
   - if @plugin_relation.compilation_file.file.exists?
+    - compilation_url = @plugin_relation.compilation_file.file.url
     .row
       .col-xs-12
         .report-call-to-action
-          a.report-download style="border: 5px solid #{@cycle.color};" href=@plugin_relation.compilation_file.file.url target="_blank"
+          a.report-download style="border: 5px solid #{@cycle.color};" href=compilation_url target="_blank"
             span Faça o Download do relatório Mudamos
             span.action-tail style="border-top: 80px solid #{@cycle.color};" &nbsp
             .hover-box style="background-color: #{@cycle.color};"
-          a.download-icon href=""
+          a.download-icon href=compilation_url target="_blank"
             .icon
               i.icon-baixeaqui style="color: #{@cycle.color};"
             | Relatorio_mudamos.pdf


### PR DESCRIPTION
This PR closes #252.

### How was it before?

- the report compilation file url would not display properly if the use hover the link

### What has changed?

- now the link is properly set

### What should I pay attention when reviewing this PR?

Nothing in particular.

### Is this PR dangerous?

No.

![screenshot 2017-04-03 10 34 34](https://cloud.githubusercontent.com/assets/252061/24611730/72d18630-1859-11e7-93ab-d90ecb34f01a.png)
