### PR TITLE
Show the app landing page only once (Issue 286)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR #295]: Show the app landing page only once (Issue 286)
 * [PR #284]: Fix report broken link (Issue 252)
 * [PR #283]: Center cycle home description when single phased (Issue 218)
 * [PR #282]: Add “scroll to” functionality to the home blocks (Issue 270)

--- a/app/controllers/cycles_controller.rb
+++ b/app/controllers/cycles_controller.rb
@@ -1,5 +1,5 @@
 class CyclesController < ApplicationController
-  before_action :home_blocks, only: %i(index)
+  before_action :home_blocks, :app_landing_page, only: %i(index)
 
   def home_block_repository
     @home_block_repository ||= HomeBlockRepository.new
@@ -17,4 +17,11 @@ class CyclesController < ApplicationController
     @home_blocks ||= home_block_repository.blocks
   end
   helper_method :home_blocks
+
+  def app_landing_page
+    unless cookies[:has_seen_app_landing]
+      cookies[:has_seen_app_landing] = true
+      render file: Rails.public_path.join("landing.html"), layout: false
+    end
+  end
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -2,8 +2,4 @@ class StaticPagesController < ApplicationController
   def show
     @static_page = StaticPage.find params[:id]
   end
-
-  def landing
-    render file: Rails.public_path.join("landing.html"), layout: false
-  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -149,8 +149,7 @@ Rails.application.routes.draw do
 
   match '/ping', to: 'ping#show', via: :get
 
-  root "static_pages#landing"
-  get "home" => "cycles#index"
+  root "cycles#index"
 
   resources :cycles, only: [:show], path: 'temas' do
     cycle_routes

--- a/public/landing.html
+++ b/public/landing.html
@@ -22,7 +22,7 @@
     <div class="wrapper">
       <div class="container">
         <h1>Chegou o novo app</h1>
-        <a href="/home" class="logo">
+        <a href="/" class="logo">
           <img src="https://s3-sa-east-1.amazonaws.com/mudamos-images/images/landing/logo.svg"/>
         </a>
         <p>Uma ferramenta para assinatura de projetos de lei de iniciativa popular de forma segura e simples.</p>
@@ -49,7 +49,7 @@
               <span class="label">Baixe agora</span>
             </a>
           </div>
-          <a href="/home" class="close">Continue para o site >></a>
+          <a href="/" class="close">Continue para o site >></a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This PR closes #286.

### How was it before?

- the app landing page was displayed to the user every time he/she accessed `/`
- the home page was mounted on `/home`

### What has changed?

- now the app landing page is displayed only once
- the home page is back to the root
- we control when displaying the landing page using a cookie

### What should I pay attention when reviewing this PR?

Nothing in particular.

### Is this PR dangerous?

No.