### PR TITLE
Changed the app store link (Issue 288)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR #296]: Changed the app store link (Issue 288)
 * [PR #295]: Show the app landing page only once (Issue 286)
 * [PR #284]: Fix report broken link (Issue 252)
 * [PR #283]: Center cycle home description when single phased (Issue 218)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 * [PR #296]: Changed the app store link (Issue 288)
+  - Set `MOBILE_APP_STORE_PAGE_IOS` to `https://itunes.apple.com/br/app/mudamos/id1214485690?ls=1&mt=8`
 * [PR #295]: Show the app landing page only once (Issue 286)
 * [PR #284]: Fix report broken link (Issue 252)
 * [PR #283]: Center cycle home description when single phased (Issue 218)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -97,4 +97,12 @@ module ApplicationHelper
       "https://s3-sa-east-1.amazonaws.com/mudamos-images/images/home-lead-mudamos-logo.svg"
     ]
   end
+
+  def mobile_app_ios_store_url
+    Rails.application.secrets.mobile_app["store_page"]["ios"]
+  end
+
+  def mobile_app_android_store_url
+    Rails.application.secrets.mobile_app["store_page"]["android"]
+  end
 end

--- a/app/views/cycles/plugin_relations/petition.html.slim
+++ b/app/views/cycles/plugin_relations/petition.html.slim
@@ -21,8 +21,8 @@ section#petition-index
                 | Recebemos sua pré-assinatura! Por um requisito legal, agora você precisa baixar o App da Mudamos para confirmar a assinatura
             .row.small-gap
               .col-xs-12
-                a.store-badge.app href="#"
-                a.store-badge.play href="#"
+                a.store-badge.app href=mobile_app_ios_store_url target="_blank"
+                a.store-badge.play href=mobile_app_android_store_url target="_blank"
           - else
             .row
               .col-xs-12

--- a/public/landing.html
+++ b/public/landing.html
@@ -29,7 +29,7 @@
         <div class="text-center">
           <div id="download-links">
             <a
-              href="https://itunes.apple.com/us/app/mudamos/id1214485690?ls=1&mt=8"
+              href="https://itunes.apple.com/br/app/mudamos/id1214485690?ls=1&mt=8"
               title="Baixar o aplicativo para dispositivos iOS"
               class="store-link"
               id="app-store"


### PR DESCRIPTION
This PR closes #288.

### How was it before?

- the ios app store link was not pointing to the brazilian store

### What has changed?

- now it does
- the pre signature store badges did not have any link

### What should I pay attention when reviewing this PR?

Nothing in particular.

### Is this PR dangerous?

No.