### PR TITLE
Remove verify document link from the menu (Issue 292)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR #297]: Remove verify document link from the menu (Issue 292)
 * [PR #296]: Changed the app store link (Issue 288)
   - Set `MOBILE_APP_STORE_PAGE_IOS` to `https://itunes.apple.com/br/app/mudamos/id1214485690?ls=1&mt=8`
 * [PR #295]: Show the app landing page only once (Issue 286)

--- a/app/views/layouts/shared/_base_header.html.slim
+++ b/app/views/layouts/shared/_base_header.html.slim
@@ -38,7 +38,6 @@
               - @cycles.each do |c|
                 li= link_to c.title, c
               li= link_to 'Reforma Política do Século 21', 'http://plataformabrasil.org.br/', target: '_blank'
-          li= link_to 'Validar Documento', verify_petitions_path
     = render 'layouts/search_bar'
 
 - if params[:controller] == 'cycles' and params[:action] == 'index'


### PR DESCRIPTION
This PR closes #292.

### How was it before?

- the verify document link was present on the base menu

### What has changed?

- now it is not

### What should I pay attention when reviewing this PR?

Nothing at all.

### Is this PR dangerous?

No.