### PR TITLE
New drop menu colors and fixed mobile interaction (Issue 289, 290)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR #300]: New drop menu colors and fixed mobile interaction (Issue 289, 290)
 * [PR #298]: Add new solution and tools home block design (Issue 293)
 * [PR #297]: Remove verify document link from the menu (Issue 292)
 * [PR #296]: Changed the app store link (Issue 288)

--- a/app/assets/javascripts/navbar-sticky.coffee
+++ b/app/assets/javascripts/navbar-sticky.coffee
@@ -11,7 +11,8 @@ $ ->
     bar.find('.notification-dropdown').css('top','-325px')
 
   if bar.length > 0
-    offset = parseInt(bar.position().top)
+    smallGap = 3
+    offset = parseInt(bar.position().top) - smallGap
 
     sticky = new Waypoint.Sticky
       element: bar[0]

--- a/app/assets/javascripts/search.js.coffee
+++ b/app/assets/javascripts/search.js.coffee
@@ -77,9 +77,6 @@ make_the_search = ->
 
         navbar_height = $('nav.navbar.navbar-default.navbar-fixed-top').height()
 
-        $('.search-results').css
-          height: "#{$(window).height() - (navbar_height)}px"
-
         document.stop_loading()
         results.fadeIn 'fast', ->
           tab = results.find('.blog-bottom-area:first').parents('.tab-pane:first')

--- a/app/assets/stylesheets/cycle/index.css.sass
+++ b/app/assets/stylesheets/cycle/index.css.sass
@@ -11,24 +11,6 @@ body
       background-color: transparent
 
 
-    .navbar-default .navbar-nav:not(.navbar-right) > .open > a, .navbar-default .navbar-nav:not(.navbar-right) > .open > a:hover, .navbar-default .navbar-nav:not(.navbar-right) > .open > a:focus
-      background: linear-gradient(90deg, rgba(17, 17, 17, 0.7) 0, rgba(17, 17, 17, 0.7) 100%), linear-gradient(90deg, rgba(81, 51, 147, 0.85) 0, rgba(81, 51, 147, 0.85) 100%), #fff
-
-    @media (max-width: $screen-xs-max)
-      #base-navbar-collapse
-        background: linear-gradient(90deg, rgba(17, 17, 17, 0.7) 0, rgba(17, 17, 17, 0.7) 100%), linear-gradient(90deg, rgba(81, 51, 147, 0.85) 0, rgba(81, 51, 147, 0.85) 100%), #fff
-        max-height: initial
-
-      .base-navbar
-        max-height: 100vh
-        overflow-y: scroll
-
-      .search-results
-        position: static
-        max-height: initial
-        overflow: initial
-        overflow-y: initial
-
     nav.navbar.navbar-default.navbar-fixed-top
       position: absolute
       top: calc(100% - #{$navbar-height})
@@ -42,33 +24,6 @@ body
         .navbar-brand,
         .navbar-toggle
           opacity: 1
-
-      &:not(.navbar-right)
-        ul.dropdown-menu
-          background: none
-          li
-            a
-              background: transparent
-
-      .dropdown-menu
-        border: none
-
-      .dropup .dropdown-menu, .navbar-fixed-bottom .dropdown .dropdown-menu
-        margin-bottom: 0
-
-      ul.dropdown-menu
-        li
-          border: none
-
-          a
-            background: linear-gradient(90deg, rgba(17, 17, 17, 0.7) 0, rgba(17, 17, 17, 0.7) 100%), linear-gradient(90deg, rgba(81, 51, 147, 0.85) 0, rgba(81, 51, 147, 0.85) 100%), #fff
-
-            &:hover
-              background: linear-gradient(90deg, rgba(17, 17, 17, 0.8) 0, rgba(17, 17, 17, 0.8) 100%), linear-gradient(90deg, rgba(81, 51, 147, 0.85) 0, rgba(81, 51, 147, 0.85) 100%), #fff
-
-    .nav.navbar-nav.navbar-right
-      a
-        background: transparent
 
 #cycles-index
   .blocks

--- a/app/assets/stylesheets/cycle/index.css.sass
+++ b/app/assets/stylesheets/cycle/index.css.sass
@@ -25,7 +25,7 @@ body
 
       .search-results
         position: static
-        height: auto
+        max-height: initial
         overflow: initial
         overflow-y: initial
 

--- a/app/assets/stylesheets/cycle/index.css.sass
+++ b/app/assets/stylesheets/cycle/index.css.sass
@@ -10,6 +10,25 @@ body
       margin-top: 30px
       background-color: transparent
 
+
+    .navbar-default .navbar-nav > .open > a, .navbar-default .navbar-nav > .open > a:hover, .navbar-default .navbar-nav > .open > a:focus
+      background: linear-gradient(90deg, rgba(17, 17, 17, 0.7) 0, rgba(17, 17, 17, 0.7) 100%), linear-gradient(90deg, rgba(81, 51, 147, 0.85) 0, rgba(81, 51, 147, 0.85) 100%), #fff
+
+    @media (max-width: $screen-xs-max)
+      #base-navbar-collapse
+        background: linear-gradient(90deg, rgba(17, 17, 17, 0.7) 0, rgba(17, 17, 17, 0.7) 100%), linear-gradient(90deg, rgba(81, 51, 147, 0.85) 0, rgba(81, 51, 147, 0.85) 100%), #fff
+        max-height: initial
+
+      .base-navbar
+        max-height: 100vh
+        overflow-y: scroll
+
+      .search-results
+        position: static
+        height: auto
+        overflow: initial
+        overflow-y: initial
+
     nav.navbar.navbar-default.navbar-fixed-top
       position: absolute
       top: calc(100% - #{$navbar-height})
@@ -23,6 +42,22 @@ body
         .navbar-brand,
         .navbar-toggle
           opacity: 1
+
+      .dropdown-menu
+        border: none
+
+      .dropup .dropdown-menu, .navbar-fixed-bottom .dropdown .dropdown-menu
+        margin-bottom: 0
+
+      ul.dropdown-menu
+        li
+          border: none
+
+          a
+            background: linear-gradient(90deg, rgba(17, 17, 17, 0.7) 0, rgba(17, 17, 17, 0.7) 100%), linear-gradient(90deg, rgba(81, 51, 147, 0.85) 0, rgba(81, 51, 147, 0.85) 100%), #fff
+
+            &:hover
+              background: linear-gradient(90deg, rgba(17, 17, 17, 0.8) 0, rgba(17, 17, 17, 0.8) 100%), linear-gradient(90deg, rgba(81, 51, 147, 0.85) 0, rgba(81, 51, 147, 0.85) 100%), #fff
 
 #cycles-index
   .blocks

--- a/app/assets/stylesheets/cycle/index.css.sass
+++ b/app/assets/stylesheets/cycle/index.css.sass
@@ -11,7 +11,7 @@ body
       background-color: transparent
 
 
-    .navbar-default .navbar-nav > .open > a, .navbar-default .navbar-nav > .open > a:hover, .navbar-default .navbar-nav > .open > a:focus
+    .navbar-default .navbar-nav:not(.navbar-right) > .open > a, .navbar-default .navbar-nav:not(.navbar-right) > .open > a:hover, .navbar-default .navbar-nav:not(.navbar-right) > .open > a:focus
       background: linear-gradient(90deg, rgba(17, 17, 17, 0.7) 0, rgba(17, 17, 17, 0.7) 100%), linear-gradient(90deg, rgba(81, 51, 147, 0.85) 0, rgba(81, 51, 147, 0.85) 100%), #fff
 
     @media (max-width: $screen-xs-max)
@@ -43,6 +43,13 @@ body
         .navbar-toggle
           opacity: 1
 
+      &:not(.navbar-right)
+        ul.dropdown-menu
+          background: none
+          li
+            a
+              background: transparent
+
       .dropdown-menu
         border: none
 
@@ -58,6 +65,10 @@ body
 
             &:hover
               background: linear-gradient(90deg, rgba(17, 17, 17, 0.8) 0, rgba(17, 17, 17, 0.8) 100%), linear-gradient(90deg, rgba(81, 51, 147, 0.85) 0, rgba(81, 51, 147, 0.85) 100%), #fff
+
+    .nav.navbar-nav.navbar-right
+      a
+        background: transparent
 
 #cycles-index
   .blocks

--- a/app/assets/stylesheets/cycle/index.css.sass
+++ b/app/assets/stylesheets/cycle/index.css.sass
@@ -14,10 +14,13 @@ body
     nav.navbar.navbar-default.navbar-fixed-top
       position: absolute
       top: calc(100% - #{$navbar-height})
-      .navbar-brand,
-      .navbar-toggle
-        opacity: 0
+      .navbar-brand, .navbar-toggle
+        opacity: 1
         +transition(opacity 0.3s ease)
+
+        @media (min-width: $screen-sm-min)
+          opacity: 0
+
       &.stuck
         position: fixed
         top: 0

--- a/app/assets/stylesheets/global.sass
+++ b/app/assets/stylesheets/global.sass
@@ -77,6 +77,7 @@ li.icon-item
 // General Styling for all pages
 nav.navbar.navbar-default
   text-align: center
+
   .container
     position: relative
   a
@@ -2067,6 +2068,10 @@ section#vocabularies-index, .vocabulary-search-result
   padding-top: 60px
   position: relative
   padding-left: 15px
+
+  @media (max-width: $screen-xs-max)
+    padding-top: 22px
+
   &.small
     .close
       top: 50%
@@ -2096,6 +2101,9 @@ section#vocabularies-index, .vocabulary-search-result
     background-color: $color-grid-light-grey
     &:focus
       outline: 0
+
+    @media (max-width: $screen-xs-max)
+      font-size: 30px
   &.small
     padding-top: 0
     .search-title-row
@@ -2109,12 +2117,10 @@ section#vocabularies-index, .vocabulary-search-result
   display: none
   background-color: white
   width: 100%
-  position: fixed
   z-index: 1000
-  height: 100vh
-  overflow: hidden
-  overflow-y: auto
   padding-bottom: 60px
+  overflow-y: scroll
+  height: 100vh
   .no-results
     color: black
     font-size: 50px

--- a/app/assets/stylesheets/global.sass
+++ b/app/assets/stylesheets/global.sass
@@ -189,7 +189,6 @@ nav.navbar.navbar-default
       color: #fff
 
   .secondary-navbar
-    height: $secondary-navbar-height
     ul.nav.navbar-nav
       li
         a
@@ -2065,19 +2064,15 @@ section#vocabularies-index, .vocabulary-search-result
 .search-bar
   display: none
   background-color: $color-grid-light-grey
-  padding-top: 60px
-  position: relative
-  padding-left: 15px
+  margin: 0
+  padding: 30px 30px 30px 15px
 
   @media (max-width: $screen-xs-max)
-    padding-top: 22px
+    padding: 15px 15px 15px 0
 
-  &.small
-    .close
-      top: 50%
-      +transform(translateY(-50%))
-      &:hover
-        +transform(translateY(-50%) scale(1.2))
+  .close
+    position: static
+    transform: initial
   .search-title
     vertical-align: middle
     font-size: 16px
@@ -2095,7 +2090,7 @@ section#vocabularies-index, .vocabulary-search-result
   input
     font-size: 70px
     font-family: $font-family-sans-serif
-    padding: 30px 0 90px 0
+    padding: 0
     width: 100%
     border: none
     background-color: $color-grid-light-grey
@@ -2105,13 +2100,10 @@ section#vocabularies-index, .vocabulary-search-result
     @media (max-width: $screen-xs-max)
       font-size: 30px
   &.small
-    padding-top: 0
     .search-title-row
       display: none
     input
       font-size: 30px
-      padding: 60px 0
-      padding-right: 120px
 
 .search-results
   display: none
@@ -2119,8 +2111,9 @@ section#vocabularies-index, .vocabulary-search-result
   width: 100%
   z-index: 1000
   padding-bottom: 60px
+  max-height: 100vh
   overflow-y: scroll
-  height: 100vh
+
   .no-results
     color: black
     font-size: 50px

--- a/app/assets/stylesheets/global.sass
+++ b/app/assets/stylesheets/global.sass
@@ -249,6 +249,10 @@ nav.navbar.navbar-default
 
 
 .base-navbar, nav.navbar.navbar-default .simple-navbar
+  @media (max-width: $screen-xs-max)
+    max-height: 100vh
+    overflow-y: scroll
+
   .search
     opacity: 0
     +transition(all 0.3s ease)
@@ -2193,7 +2197,7 @@ section#vocabularies-index, .vocabulary-search-result
   width: 100%
   z-index: 1000
   padding-bottom: 60px
-  max-height: 100vh
+  max-height: 50vh
   overflow-y: scroll
 
   .no-results

--- a/app/assets/stylesheets/global.sass
+++ b/app/assets/stylesheets/global.sass
@@ -268,19 +268,19 @@ nav.navbar.navbar-default
   .nav.navbar-nav
     .dropdown.open
       a
-        background: linear-gradient(90deg, rgba(17, 17, 17, 0.7) 0, rgba(17, 17, 17, 0.7) 100%), linear-gradient(90deg, rgba(81, 51, 147, 0.85) 0, rgba(81, 51, 147, 0.85) 100%), #fff
+        background: linear-gradient(90deg, rgba(17, 17, 17, 0.7), rgba(17, 17, 17, 0.7)), linear-gradient(90deg, rgba(81, 51, 147, 0.85), rgba(81, 51, 147, 0.85)), #fff
         &:hover
-          background: linear-gradient(90deg, rgba(17, 17, 17, 0.8) 0, rgba(17, 17, 17, 0.8) 100%), linear-gradient(90deg, rgba(81, 51, 147, 0.85) 0, rgba(81, 51, 147, 0.85) 100%), #fff
+          background: linear-gradient(90deg, rgba(17, 17, 17, 0.8), rgba(17, 17, 17, 0.8)), linear-gradient(90deg, rgba(81, 51, 147, 0.85), rgba(81, 51, 147, 0.85)), #fff
       ul.dropdown-menu
         li
           border: none
           border-color: transparent
 
           a
-            background: linear-gradient(90deg, rgba(17, 17, 17, 0.7) 0, rgba(17, 17, 17, 0.7) 100%), linear-gradient(90deg, rgba(81, 51, 147, 0.85) 0, rgba(81, 51, 147, 0.85) 100%), #fff
+            background: linear-gradient(90deg, rgba(17, 17, 17, 0.7), rgba(17, 17, 17, 0.7)), linear-gradient(90deg, rgba(81, 51, 147, 0.85), rgba(81, 51, 147, 0.85)), #fff
 
             &:hover
-              background: linear-gradient(90deg, rgba(17, 17, 17, 0.8) 0, rgba(17, 17, 17, 0.8) 100%), linear-gradient(90deg, rgba(81, 51, 147, 0.85) 0, rgba(81, 51, 147, 0.85) 100%), #fff
+              background: linear-gradient(90deg, rgba(17, 17, 17, 0.8), rgba(17, 17, 17, 0.8)), linear-gradient(90deg, rgba(81, 51, 147, 0.85), rgba(81, 51, 147, 0.85)), #fff
 
   @media (max-width: $screen-xs-max)
     .dropdown.user-dropdown.open .dropdown-menu
@@ -306,7 +306,7 @@ nav.navbar.navbar-default
 
   @media (max-width: $screen-xs-max)
     #base-navbar-collapse
-      background: linear-gradient(90deg, rgba(17, 17, 17, 0.7) 0, rgba(17, 17, 17, 0.7) 100%), linear-gradient(90deg, rgba(81, 51, 147, 0.85) 0, rgba(81, 51, 147, 0.85) 100%), #fff
+      background: linear-gradient(90deg, rgba(17, 17, 17, 0.7), rgba(17, 17, 17, 0.7)), linear-gradient(90deg, rgba(81, 51, 147, 0.85), rgba(81, 51, 147, 0.85)), #fff
       max-height: initial
 
     .base-navbar

--- a/app/assets/stylesheets/global.sass
+++ b/app/assets/stylesheets/global.sass
@@ -77,6 +77,7 @@ li.icon-item
 // General Styling for all pages
 nav.navbar.navbar-default
   text-align: center
+  border: none
 
   .container
     position: relative
@@ -235,7 +236,7 @@ nav.navbar.navbar-default
         vertical-align: middle
 
       &+ span
-        max-width: 48px
+        max-width: 15vw
         text-overflow: ellipsis
         overflow: hidden
         display: inline-block
@@ -247,7 +248,7 @@ nav.navbar.navbar-default
           display: initial
 
 
-.base-navbar
+.base-navbar, nav.navbar.navbar-default .simple-navbar
   .search
     opacity: 0
     +transition(all 0.3s ease)
@@ -286,7 +287,7 @@ nav.navbar.navbar-default
 
     .nav.navbar-nav.navbar-right
       background: none
-      display: block
+      display: inline-block
       float: none
 
       li.dropdown.open
@@ -320,6 +321,16 @@ nav.navbar.navbar-default
     a
       cursor: pointer !important
 
+nav.navbar.navbar-default .simple-navbar
+  .nav.navbar-nav.navbar-right
+    float: right
+    margin-left: 0
+    margin-right: -50px
+
+    @media (min-width: $screen-sm-min)
+      margin-right: -50px
+    @media (min-width: $screen-md-min)
+      margin-right: -15px
 
 .body-container > nav:first-child + section.auto-spacing
   padding: 22px 0
@@ -2792,7 +2803,6 @@ a.copy-to-clipboard
 .nav.navbar-nav.navbar-center.non-cycle
   @media (max-width: $screen-xs-max)
     display: block
-    margin-top: 60px
 nav.navbar.navbar-default ul.navbar-center.non-cycle li
   @media (max-width: $screen-xs-max)
     display: block

--- a/app/assets/stylesheets/global.sass
+++ b/app/assets/stylesheets/global.sass
@@ -243,6 +243,59 @@ nav.navbar.navbar-default
     +transition(all 0.3s ease)
     a
       cursor: default
+
+  .dropdown-menu
+    border: none
+
+  .dropup .dropdown-menu, .navbar-fixed-bottom .dropdown .dropdown-menu
+    margin-bottom: 0
+
+  .nav.navbar-nav
+    .dropdown.open
+      a
+        background: linear-gradient(90deg, rgba(17, 17, 17, 0.7) 0, rgba(17, 17, 17, 0.7) 100%), linear-gradient(90deg, rgba(81, 51, 147, 0.85) 0, rgba(81, 51, 147, 0.85) 100%), #fff
+        &:hover
+          background: linear-gradient(90deg, rgba(17, 17, 17, 0.8) 0, rgba(17, 17, 17, 0.8) 100%), linear-gradient(90deg, rgba(81, 51, 147, 0.85) 0, rgba(81, 51, 147, 0.85) 100%), #fff
+      ul.dropdown-menu
+        li
+          border: none
+          border-color: transparent
+
+          a
+            background: linear-gradient(90deg, rgba(17, 17, 17, 0.7) 0, rgba(17, 17, 17, 0.7) 100%), linear-gradient(90deg, rgba(81, 51, 147, 0.85) 0, rgba(81, 51, 147, 0.85) 100%), #fff
+
+            &:hover
+              background: linear-gradient(90deg, rgba(17, 17, 17, 0.8) 0, rgba(17, 17, 17, 0.8) 100%), linear-gradient(90deg, rgba(81, 51, 147, 0.85) 0, rgba(81, 51, 147, 0.85) 100%), #fff
+
+  @media (max-width: $screen-xs-max)
+    .nav.navbar-nav.navbar-right
+      background: none
+
+      li.dropdown.open
+        background: none
+        .dropdown-menu, a
+          background: none
+
+          li
+            border: none
+            a
+              background: none
+
+  @media (max-width: $screen-xs-max)
+    #base-navbar-collapse
+      background: linear-gradient(90deg, rgba(17, 17, 17, 0.7) 0, rgba(17, 17, 17, 0.7) 100%), linear-gradient(90deg, rgba(81, 51, 147, 0.85) 0, rgba(81, 51, 147, 0.85) 100%), #fff
+      max-height: initial
+
+    .base-navbar
+      max-height: 100vh
+      overflow-y: scroll
+
+    .search-results
+      position: static
+      max-height: initial
+      overflow: initial
+      overflow-y: initial
+
 .base-navbar.stuck
   .search
     opacity: 1 !important

--- a/app/assets/stylesheets/global.sass
+++ b/app/assets/stylesheets/global.sass
@@ -208,6 +208,16 @@ nav.navbar.navbar-default
     font-size: 16px
     font-weight: 300
   .user-dropdown
+    .dropdown-menu
+      position: absolute
+      top: 100%
+      left: 0
+
+      li
+        width: 100%
+
+      @media (max-width: $screen-xs-max)
+        position: absolute
     a
       padding: 10px 20px
     .user-menu-image
@@ -268,8 +278,16 @@ nav.navbar.navbar-default
               background: linear-gradient(90deg, rgba(17, 17, 17, 0.8) 0, rgba(17, 17, 17, 0.8) 100%), linear-gradient(90deg, rgba(81, 51, 147, 0.85) 0, rgba(81, 51, 147, 0.85) 100%), #fff
 
   @media (max-width: $screen-xs-max)
+    .dropdown.user-dropdown.open .dropdown-menu
+      position: static
+
+      li
+        width: initial
+
     .nav.navbar-nav.navbar-right
       background: none
+      display: block
+      float: none
 
       li.dropdown.open
         background: none

--- a/app/views/layouts/_search_bar.html.slim
+++ b/app/views/layouts/_search_bar.html.slim
@@ -7,9 +7,10 @@
           | Buscar
         p.search-sub-title Comece digitando algo...
     .row
-      .col-xs-12.text-left
+      .col-xs-10.text-left
         = text_field_tag :search, params[:search], onkeyup: "this.setAttribute('value', this.value);", autocomplete: :off
-    .close
-      i.icon-close
+      .col-xs-2
+        .close
+          i.icon-close
 
 .search-results


### PR DESCRIPTION
This PR closes both #290 and #289.

### How was it before?

- the new home menu had the old black dropdowns
- the mobile interaction was broken on several cases

### What has changed?

- added new colos to the dropdown
- fixed mobile interaction when displaying sub menus
- fixed mobile interaction when searching
- applied the new style to all base navbars

### What should I pay attention when reviewing this PR?

This is basically a css PR. So good luck.

### Is this PR dangerous?

Maybe a broke some other menus, but the ones I tested, looked okay.

![screenshot 2017-04-04 17 20 28](https://cloud.githubusercontent.com/assets/252061/24677296/b8135062-195c-11e7-9fa0-551ff3459e2a.png)
![screenshot 2017-04-04 17 20 42](https://cloud.githubusercontent.com/assets/252061/24677297/b81b06c2-195c-11e7-8d80-8eb6e5619c50.png)
![screenshot 2017-04-04 17 21 18](https://cloud.githubusercontent.com/assets/252061/24677298/b81e1e84-195c-11e7-88c8-95a022e9377d.png)
![screenshot 2017-04-04 17 21 30](https://cloud.githubusercontent.com/assets/252061/24677299/b821ac20-195c-11e7-969b-053a56fea7fe.png)
![screenshot 2017-04-04 17 21 38](https://cloud.githubusercontent.com/assets/252061/24677300/b8268588-195c-11e7-99b7-057e8bb192c3.png)
![screenshot 2017-04-04 17 21 46](https://cloud.githubusercontent.com/assets/252061/24677301/b8298864-195c-11e7-9c21-3380acaec2b7.png)
![screenshot 2017-04-04 17 21 59](https://cloud.githubusercontent.com/assets/252061/24677302/b836ba98-195c-11e7-9f9f-f5327c87c53f.png)
![screenshot 2017-04-04 17 23 18](https://cloud.githubusercontent.com/assets/252061/24677303/b8439ef2-195c-11e7-95c4-9a4d935e47de.png)
![screenshot 2017-04-04 17 23 31](https://cloud.githubusercontent.com/assets/252061/24677304/b8442386-195c-11e7-8d32-ebaee0aa83b2.png)
![screenshot 2017-04-04 17 24 25](https://cloud.githubusercontent.com/assets/252061/24677305/b8480cda-195c-11e7-884e-794a0704a9d2.png)
![screenshot 2017-04-04 17 24 44](https://cloud.githubusercontent.com/assets/252061/24677306/b84e93e8-195c-11e7-9004-5a1503e7c871.png)
![screenshot 2017-04-04 17 24 51](https://cloud.githubusercontent.com/assets/252061/24677307/b852ae38-195c-11e7-8840-655e281e1246.png)
![apr-04-2017 17-26-09](https://cloud.githubusercontent.com/assets/252061/24677319/c925f71a-195c-11e7-88aa-5a04d72ca2af.gif)

