### PR TITLE
Add app landing cookie as secure and httponly (Issue 301)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR #302]: Add app landing cookie as secure and httponly (Issue 301)
 * [PR #300]: New drop menu colors and fixed mobile interaction (Issue 289, 290)
 * [PR #298]: Add new solution and tools home block design (Issue 293)
 * [PR #297]: Remove verify document link from the menu (Issue 292)

--- a/app/controllers/cycles_controller.rb
+++ b/app/controllers/cycles_controller.rb
@@ -20,7 +20,13 @@ class CyclesController < ApplicationController
 
   def app_landing_page
     unless cookies[:has_seen_app_landing]
-      cookies[:has_seen_app_landing] = true
+      cookies[:has_seen_app_landing] = {
+        value: true,
+        expires: 1.year.from_now,
+        secure: !Rails.env.development?,
+        httponly: true
+      }
+
       render file: Rails.public_path.join("landing.html"), layout: false
     end
   end


### PR DESCRIPTION
This PR closes #301.

### How was it before?

- the app landing cookie was using the session config

### What has changed?

- now it is secure, httponly, and will expire after 1 year

### What should I pay attention when reviewing this PR?

Nothing in particular.

### Is this PR dangerous?

No.