### PR TITLE
Fix app landing scroll (Issue 285)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR #303]: Fix app landing scroll (Issue 285)
 * [PR #302]: Add app landing cookie as secure and httponly (Issue 301)
 * [PR #300]: New drop menu colors and fixed mobile interaction (Issue 289, 290)
 * [PR #298]: Add new solution and tools home block design (Issue 293)

--- a/public/style.css
+++ b/public/style.css
@@ -6,6 +6,7 @@ body {
   background:
     linear-gradient(105deg, rgba(0, 0, 0, 0.24) 42%, transparent 70%),
     url("https://s3-sa-east-1.amazonaws.com/mudamos-images/images/landing/background.png") #dedede;
+  background-attachment: fixed;
   font-family: "Nunito", sans-serif;
   height: 100%;
   min-height: 100%;
@@ -72,8 +73,9 @@ p {
 }
 
 .mockup img {
-  width: 100%;
-  max-width: 568px;
+  height: calc(100vh - 40px);
+  max-height: 698px;
+  min-height: 570px;
 }
 
 .clearfix {
@@ -170,7 +172,7 @@ a {
 
 .wrapper {
   width: 60%;
-  padding: 120px 0;
+  padding: 40px 0;
 }
 
 @media (min-width: 1500px) {
@@ -231,5 +233,6 @@ a {
 
   .wrapper {
     width: 100%;
+    padding: 80px 0 10px;
   }
 }


### PR DESCRIPTION
This PR closes #285.

### How was it before?

- the landing had a scroll while on a medium sized view port

### What has changed?

- now only heights less 600px will have a scroll
- fixed background image

### What should I pay attention when reviewing this PR?

Nothing in particular.

### Is this PR dangerous?

No.

![screenshot 2017-04-05 13 53 54](https://cloud.githubusercontent.com/assets/252061/24717203/04e06226-1a08-11e7-9b84-cef449df3760.png)
![screenshot 2017-04-05 13 54 04](https://cloud.githubusercontent.com/assets/252061/24717202/04dfa1f6-1a08-11e7-80c5-dfc6fa246f08.png)
![screenshot 2017-04-05 13 54 21](https://cloud.githubusercontent.com/assets/252061/24717200/04db5f88-1a08-11e7-9375-28d55f69960c.png)
![screenshot 2017-04-05 13 54 35](https://cloud.githubusercontent.com/assets/252061/24717201/04dd0fae-1a08-11e7-850b-e91da728ae06.png)
