### PR TITLE
Fix landing scroll after animations (Issue 308)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [1.9.0] - 07/04/2017
 
+* [PR #309]: Fix landing scroll after animations (Issue 308)
 * [PR #306]: Add animations to the app landing page (Issue 287)
 * [PR #305]: Add cycles to home (Issue 294)
 * [PR #304]: Glue the solution home block to the tools together (Issue 299)

--- a/public/style.css
+++ b/public/style.css
@@ -107,7 +107,7 @@ a {
 }
 
 .drawing {
-  position: absolute;
+  position: fixed;
   z-index: -1;
 }
 


### PR DESCRIPTION
This PR closes #308.

### How was it before?

- the app landing page had a scroll after adding the new animations

### What has changed?

- the flying images are now position fixed

### What should I pay attention when reviewing this PR?

Nothing in particular.

### Is this PR dangerous?

No.