### PR TITLE
Force hide “Informe-se” in the cycle menu (Issue 316)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR #317]: Force hide “Informe-se” in the cycle menu (Issue 316)
 * [PR #315]: Fix pdf generation with hardcoded data (Issue 314)
 
 ## [1.11.0] - 10/04/2017

--- a/app/views/layouts/shared/_cycle_header.html.slim
+++ b/app/views/layouts/shared/_cycle_header.html.slim
@@ -29,7 +29,8 @@ nav.navbar.navbar-default.navbar-fixed-top
           - if @cycle.blog_plugin.present?
             li= link_to 'BLOG', cycle_blog_posts_path(@cycle)
 
-          - if @cycle.past_phases.any? or @cycle.plugins.where(plugin_type: ["Biblioteca", "Glossário"]).where.not(plugin_type: 'Blog').any?
+          - should_hide_information = @cycle.name != "Segurança Pública"
+          - if !should_hide_information && (@cycle.past_phases.any? || @cycle.plugins.where(plugin_type: ["Biblioteca", "Glossário"]).where.not(plugin_type: 'Blog').any?)
             li.dropdown
               = link_to '#', class: 'dropdown-toggle', data: { toggle: 'dropdown' }, aria: { haspopup: 'true', expanded: 'false' }, role: 'button' do
                 | INFORME-SE


### PR DESCRIPTION
This PR closes #316.

### How was it before?

- both "Biblioteca" and "Glossário" which can be found on the "Informe-se" link (cycle menu) has hardcoded data about the "Segurança pública" cycle

### What has changed?

- hiding the entry when the cycle is not "Segurança pública"

### What should I pay attention when reviewing this PR?

Nothing in particular.

### Is this PR dangerous?

No.