### PR TITLE
Fix wrong signatures count progress bar (Issue 320)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR #321]: Fix wrong signatures count progress bar (Issue 320)
 * [PR #319]: Change petition label and video position (Issue 318)
 * [PR #317]: Force hide “Informe-se” in the cycle menu (Issue 316)
 * [PR #315]: Fix pdf generation with hardcoded data (Issue 314)

--- a/app/assets/javascripts/progress-bar.js
+++ b/app/assets/javascripts/progress-bar.js
@@ -29,7 +29,7 @@
 
       $container.append($marker);
 
-      $container.on("update", function(percentage) {
+      $container.on("update", function(event, percentage) {
         $currentPercentageBar.css("width", percentage);
         $marker.css("left", percentage);
       });

--- a/app/views/cycles/plugin_relations/petition.html.slim
+++ b/app/views/cycles/plugin_relations/petition.html.slim
@@ -164,7 +164,6 @@ javascript:
       $("#petition-signers-tablet").muPetitionSignersSmall(#{@petition.id}, petitionInProgress, apiClient);
 
       var progressBar = $(".petition-signatures-progress").progressBar({
-        percentage: "20%",
         color: "#{@cycle.color}"
       });
 


### PR DESCRIPTION
This PR closes #320.

### How was it before?

- the signatures count progress bar was wrong

### What has changed?

- using the correct percentage
- do not initialize it with *20%*

### What should I pay attention when reviewing this PR?

Nothing in particular.

### Is this PR dangerous?

No. 