### PR TITLE
Simplify the pre signature process (Issue 322)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* [PR #323]: Simplify the pre signature process (Issue 322)
+  - Run `rake db:migrate`
 * [PR #321]: Fix wrong signatures count progress bar (Issue 320)
 * [PR #319]: Change petition label and video position (Issue 318)
 * [PR #317]: Force hide “Informe-se” in the cycle menu (Issue 316)

--- a/app/assets/javascripts/routes.js.erb
+++ b/app/assets/javascripts/routes.js.erb
@@ -1,1 +1,1 @@
-<%= JsRoutes.generate(namespace: "AppRoutes", exclude: /admin/) %>
+<%= JsRoutes.generate(namespace: "AppRoutes", exclude: /admin/)  %>

--- a/app/assets/javascripts/sign_petition.js
+++ b/app/assets/javascripts/sign_petition.js
@@ -31,28 +31,40 @@
     });
   }
 
+  function checkStore() {
+    const userAgent = navigator.userAgent || navigator.vendor;
+    const GOOGLE_PLAY_URL = "https://play.google.com/store/apps/details?id=org.mudamos.petition";
+    const APP_STORE_URL = "https://itunes.apple.com/br/app/mudamos/id1214485690?ls=1&mt=8";
+
+    var $modal = $("#modal_petition_sign");
+
+    if (/android/i.test(userAgent)) {
+      $modal.find("input[type=radio][value=android]").attr("checked", "checked");
+    } else if (/iPad|iPhone|iPod/.test(userAgent) && !window.MSStream) {
+      $modal.find("input[type=radio][value=ios]").attr("checked", "checked");
+    }
+  }
+
   $(document).ready(function() {
+    var $form = $("form#new_petition_approver");
+
     $("body").on("click", ".sign-petition", function(e) {
       e.preventDefault();
 
       $("#modal_petition_sign").modal("show");
     });
 
-    $(function() {
-      const userAgent = navigator.userAgent || navigator.vendor;
-      const GOOGLE_PLAY_URL = "https://play.google.com/store/apps/details?id=org.mudamos.petition";
-      const APP_STORE_URL = "https://itunes.apple.com/br/app/mudamos/id1214485690?ls=1&mt=8";
+    checkStore();
 
-      var $modal = $("#modal_petition_sign");
+    function validateForm() {
+      var email = $form.find("input[type='email']").val().trim() !== "";
+      var store = $form.find("input[type=radio]:checked").val() != null;
 
-      if (/android/i.test(userAgent)) {
-        $modal.find(".store-badge.app").remove();
-      } else if (/iPad|iPhone|iPod/.test(userAgent) && !window.MSStream) {
-        $modal.find(".store-badge.play").remove();
-      }
-    });
+      var valid = email && store;
+      $form.find("button[type=submit]").attr("disabled", !valid);
+    }
 
-    $("form#new_petition_approver")
+    $form
       .attr("action", AppRoutes.petitionApprovePath(pluginRelationId()))
       .on("ajax:beforeSend", function() {
         document.start_loading();
@@ -61,16 +73,17 @@
       .on("ajax:complete", function() {
         document.stop_loading();
       })
-      .on("ajax:success", function() {
-        $(this).slideUp().closest(".modal-body").find(".result .success").text("Obrigado! Agora baixe o aplicativo em uma das lojas abaixo.")
+      .on("ajax:success", function(event, data) {
+        $form.closest(".modal").modal("hide");
+        location.href = data.store;
       })
       .on("ajax:error", function() {
         $(this).closest(".modal-body").find(".result .error").text("Houve um erro. Por favor tente novamente mais tarde.");
       })
       .find("input[type='email']")
-        .on("keyup", function() {
-          $(this).closest("form").find("button").attr("disabled", $(this).val().trim() === "");
-        });
+        .on("keyup", validateForm);
+
+      $form.find("input[type=radio]").on("change", validateForm);
   });
 
 })(jQuery, document, location);

--- a/app/assets/javascripts/sign_petition.js
+++ b/app/assets/javascripts/sign_petition.js
@@ -35,15 +35,42 @@
     $("body").on("click", ".sign-petition", function(e) {
       e.preventDefault();
 
-      if (isLoggedIn()) {
-        signPetition();
-      } else {
-        document.open_login(function() {
-          $("#modal-session-new, #modal-registration-new").modal("hide");
-          signPetition()
-        });
+      $("#modal_petition_sign").modal("show");
+    });
+
+    $(function() {
+      const userAgent = navigator.userAgent || navigator.vendor;
+      const GOOGLE_PLAY_URL = "https://play.google.com/store/apps/details?id=org.mudamos.petition";
+      const APP_STORE_URL = "https://itunes.apple.com/br/app/mudamos/id1214485690?ls=1&mt=8";
+
+      var $modal = $("#modal_petition_sign");
+
+      if (/android/i.test(userAgent)) {
+        $modal.find(".store-badge.app").remove();
+      } else if (/iPad|iPhone|iPod/.test(userAgent) && !window.MSStream) {
+        $modal.find(".store-badge.play").remove();
       }
     });
+
+    $("form#new_petition_approver")
+      .attr("action", AppRoutes.petitionApprovePath(pluginRelationId()))
+      .on("ajax:beforeSend", function() {
+        document.start_loading();
+        $(this).closest(".modal-body").find(".result .error").text("");
+      })
+      .on("ajax:complete", function() {
+        document.stop_loading();
+      })
+      .on("ajax:success", function() {
+        $(this).slideUp().closest(".modal-body").find(".result .success").text("Obrigado! Agora baixe o aplicativo em uma das lojas abaixo.")
+      })
+      .on("ajax:error", function() {
+        $(this).closest(".modal-body").find(".result .error").text("Houve um erro. Por favor tente novamente mais tarde.");
+      })
+      .find("input[type='email']")
+        .on("keyup", function() {
+          $(this).closest("form").find("button").attr("disabled", $(this).val().trim() === "");
+        });
   });
 
 })(jQuery, document, location);

--- a/app/assets/stylesheets/global.sass
+++ b/app/assets/stylesheets/global.sass
@@ -2923,6 +2923,9 @@ nav.navbar.navbar-default ul.dropdown-menu.cycle
   line-height: 20px
   text-transform: uppercase
 
+  &[disabled="disabled"]
+    opacity: 0.7
+
   &.new
     padding: 12px
     height: 43px
@@ -3300,3 +3303,8 @@ form.user-profile
 
 .margin-less
   margin: 0
+
+#modal_petition_sign
+  .result
+    color: rgba(43, 39, 39, 0.57)
+    margin-bottom: 15px

--- a/app/assets/stylesheets/petition/index.css.sass
+++ b/app/assets/stylesheets/petition/index.css.sass
@@ -323,3 +323,16 @@
 
       .version
         font-weight: bold
+
+#new_petition_approver
+  .stores
+    margin-left: 15px
+    margin-top: 30px
+
+    li
+      label
+        cursor: pointer
+
+        input[type=radio]
+          margin-left: calc(50% - 16px)
+          margin-bottom: 10px

--- a/app/controllers/petitions_controller.rb
+++ b/app/controllers/petitions_controller.rb
@@ -13,6 +13,12 @@ class PetitionsController < ApplicationController
     params[:action] == "verify"
   end
 
+  def approve
+    attrs = params.require(:approver).permit(:email)
+    PetitionPlugin::Approver.find_or_create_by email: attrs[:email], plugin_relation_id: params[:petition_id]
+    head :ok
+  end
+
   private
 
   def petition

--- a/app/controllers/petitions_controller.rb
+++ b/app/controllers/petitions_controller.rb
@@ -16,10 +16,15 @@ class PetitionsController < ApplicationController
   def approve
     attrs = params.require(:approver).permit(:email)
     PetitionPlugin::Approver.find_or_create_by email: attrs[:email], plugin_relation_id: params[:petition_id]
-    head :ok
+    render json: { store: url_for_store }
   end
 
   private
+
+  def url_for_store
+    store = Rails.application.secrets.mobile_app["store_page"]
+    store[params[:store] == "ios" ? "ios" : "android"]
+  end
 
   def petition
     @petition ||= petition_repository.find_by_id!(params[:petition_id])

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -65,6 +65,8 @@ module ApplicationHelper
       'number_field'
     when :check_box
       'check_box'
+    when :email
+      'email_field'
     else
       'text_field'
     end

--- a/app/models/petition_plugin/approver.rb
+++ b/app/models/petition_plugin/approver.rb
@@ -1,0 +1,9 @@
+require_dependency "../petition_plugin"
+
+class PetitionPlugin::Approver < ActiveRecord::Base
+  include PetitionPlugin
+
+  belongs_to :plugin_relation
+
+  validates :email, uniqueness: { scope: :plugin_relation_id }, presence: true
+end

--- a/app/views/cycles/plugin_relations/petition.html.slim
+++ b/app/views/cycles/plugin_relations/petition.html.slim
@@ -133,6 +133,9 @@ section#petition-index
 
       = render 'layouts/shared/footer'
 
+- content_for :modals
+  = render "layouts/shared/modal", modal_id: 'modal_petition_sign', size: 'sm', cache: true, content: render(file: "cycles/plugin_relations/petition_sign_modal")
+
 css:
   .petition-side-bar {
     background-image:

--- a/app/views/cycles/plugin_relations/petition_sign_modal.html.slim
+++ b/app/views/cycles/plugin_relations/petition_sign_modal.html.slim
@@ -1,14 +1,12 @@
 .modal-body
   .row
     .col-xs-12
-      span Entre com seu email abaixo para receber mais informações
+      span Digite seu e-mail e escolha a plataforma para abaixar o App de Assinatura
   .row.dividers
     .col-xs-12
       hr
 
   .row.result
-    .col-xs-12
-      span.success
     .col-xs-12
       span.error
 
@@ -16,11 +14,14 @@
     = f.inputs class: "col-xs-12" do
       = input f, :email, as: :email, label: 'Email'
 
-    .col-xs-12
-      button.rounded-button.new type="submit" disabled="disabled" Enviar
+    ol.col-xs-12.stores.list-inline
+      li
+        label
+          input.app type="radio" value="ios" name="store" required="required"
+          .store-badge.app
+        label
+          input.app type="radio" value="android" name="store" required="required"
+          .store-badge.play
 
-.modal-footer
-  .row
     .col-xs-12
-      a.store-badge.app href=mobile_app_ios_store_url target="_blank" style="margin-right: 15px"
-      a.store-badge.play href=mobile_app_android_store_url target="_blank"
+      button.rounded-button.new type="submit" disabled="disabled" Baixar

--- a/app/views/cycles/plugin_relations/petition_sign_modal.html.slim
+++ b/app/views/cycles/plugin_relations/petition_sign_modal.html.slim
@@ -1,0 +1,26 @@
+.modal-body
+  .row
+    .col-xs-12
+      span Entre com seu email abaixo para receber mais informações
+  .row.dividers
+    .col-xs-12
+      hr
+
+  .row.result
+    .col-xs-12
+      span.success
+    .col-xs-12
+      span.error
+
+  = semantic_form_for PetitionPlugin::Approver.new, as: :approver, url: "", html: { id: "new_petition_approver", class: "row", novalidate: nil }, remote: true do |f|
+    = f.inputs class: "col-xs-12" do
+      = input f, :email, as: :email, label: 'Email'
+
+    .col-xs-12
+      button.rounded-button.new type="submit" disabled="disabled" Enviar
+
+.modal-footer
+  .row
+    .col-xs-12
+      a.store-badge.app href=mobile_app_ios_store_url target="_blank" style="margin-right: 15px"
+      a.store-badge.play href=mobile_app_android_store_url target="_blank"

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -64,3 +64,6 @@ html
         = render 'layouts/shared/modal', modal_id: 'modal-passwords-edit', size: 'sm', cache: true, content: render(file: 'users/passwords/edit')
         javascript:
           $('#modal-passwords-edit').modal('show');
+
+      - if yield :modals
+        = yield :modals

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -167,5 +167,6 @@ Rails.application.routes.draw do
   resources :petitions, only: [] do
     get :verify, on: :collection
     get :signatures
+    post :approve
   end
 end

--- a/db/migrate/20170411113811_create_petition_plugin_approvers.rb
+++ b/db/migrate/20170411113811_create_petition_plugin_approvers.rb
@@ -1,0 +1,12 @@
+class CreatePetitionPluginApprovers < ActiveRecord::Migration
+  def change
+    create_table :petition_plugin_approvers do |t|
+      t.string :email, null: false
+      t.references :plugin_relation, index: true, foreign_key: { on_delete: :cascade }, null: false
+
+      t.timestamps null: false
+    end
+
+    add_index :petition_plugin_approvers, %i(email plugin_relation_id), name: :index_petition_approvers, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170328114132) do
+ActiveRecord::Schema.define(version: 20170411113811) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -332,6 +332,16 @@ ActiveRecord::Schema.define(version: 20170328114132) do
 
   add_index "permissions", ["deleted_at"], name: "index_permissions_on_deleted_at", using: :btree
 
+  create_table "petition_plugin_approvers", force: :cascade do |t|
+    t.string   "email",              null: false
+    t.integer  "plugin_relation_id", null: false
+    t.datetime "created_at",         null: false
+    t.datetime "updated_at",         null: false
+  end
+
+  add_index "petition_plugin_approvers", ["email", "plugin_relation_id"], name: "index_petition_approvers", unique: true, using: :btree
+  add_index "petition_plugin_approvers", ["plugin_relation_id"], name: "index_petition_plugin_approvers_on_plugin_relation_id", using: :btree
+
   create_table "petition_plugin_detail_versions", force: :cascade do |t|
     t.integer  "petition_plugin_detail_id",                 null: false
     t.string   "document_url"
@@ -638,6 +648,7 @@ ActiveRecord::Schema.define(version: 20170328114132) do
   add_foreign_key "oauth_access_grants", "users", column: "resource_owner_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_tokens", "users", column: "resource_owner_id"
+  add_foreign_key "petition_plugin_approvers", "plugin_relations", on_delete: :cascade
   add_foreign_key "petition_plugin_detail_versions", "petition_plugin_details", on_delete: :cascade
   add_foreign_key "petition_plugin_details", "plugin_relations", on_delete: :cascade
   add_foreign_key "petition_plugin_presignatures", "plugin_relations", on_delete: :cascade

--- a/public/landing.html
+++ b/public/landing.html
@@ -73,7 +73,7 @@
         $(function() {
           const userAgent = navigator.userAgent || navigator.vendor;
           const GOOGLE_PLAY_URL = "https://play.google.com/store/apps/details?id=org.mudamos.petition";
-          const APP_STORE_URL = "https://itunes.apple.com/us/app/mudamos/id1214485690?ls=1&mt=8";
+          const APP_STORE_URL = "https://itunes.apple.com/br/app/mudamos/id1214485690?ls=1&mt=8";
 
           if (/android/i.test(userAgent)) {
             $("#download-links .store-link").addClass("hidden");


### PR DESCRIPTION
This PR closes #322.

### How was it before?

- users had to login in order to pre sign the petition

### What has changed?

- now they only have to type an email
- these emails are stored with the plugin relation
- run `rake db:migrate`

### What should I pay attention when reviewing this PR?

Nothing in particular.

### Is this PR dangerous?

No.

![screenshot 2017-04-11 12 12 12](https://cloud.githubusercontent.com/assets/252061/24916564/e125c620-1eb0-11e7-8cd5-20beb456342a.png)
