### PR TITLE
Fix “Incorporar” css issues (Issue 324)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [1.12.0] - 11/04/2017
 
+* [PR #325]: Fix “Incorporar” css issues (Issue 324)
 * [PR #323]: Simplify the pre signature process (Issue 322)
   - Run `rake db:migrate`
 * [PR #321]: Fix wrong signatures count progress bar (Issue 320)

--- a/app/assets/stylesheets/embedded/petitions.sass
+++ b/app/assets/stylesheets/embedded/petitions.sass
@@ -89,19 +89,21 @@ body
 
         &.finished
           background-color: #757575
-    
+
     .petition-body
       display: none
       font-size: 14px
       font-weight: 300
       line-height: 18px
       height: 240px
+      overflow-y: scroll
       color: rgba(78 ,78 ,78, 0.85)
       margin: 16px 16px 0px 16px
 
       p
-        margin-bottom: 0px
-    
+        margin: 0
+        white-space: pre-line
+
     .petition-bottom-information
       display: none
       height: 35px

--- a/app/assets/stylesheets/petition/index.css.sass
+++ b/app/assets/stylesheets/petition/index.css.sass
@@ -128,6 +128,7 @@
       color: rgba(77, 77, 77, 0.85)
       line-height: 39px
       font-weight: 300
+      white-space: pre-line
 
   .petition-view
     .footer-nav


### PR DESCRIPTION
This PR closes #324.

### How was it before?

- the petition presentation had no scroll
- it did not preserve the line breaks