### PR TITLE
Hide “incorporar” share if not on a desktop (Issue 340)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR #341]: Hide “incorporar” share if not on a desktop (Issue 340)
 * [PR #339]: Do not show the landing page if it is the petition page (Issue 338)
 * [PR #337]: Parsing mobile api timestamps in the BRST zone (Issue 336)
 * [PR #335]: Fix typo on footer (Issue 334)

--- a/app/assets/stylesheets/petition/index.css.sass
+++ b/app/assets/stylesheets/petition/index.css.sass
@@ -18,11 +18,15 @@
     margin-top: 16px
 
   .embedded-link
+    display: none
     height: 10px
     margin-bottom: 20px
 
     strong
       cursor: pointer
+
+    @media (min-width: $screen-md-min)
+      display: block
 
   #petition-signers-desktop
     .title


### PR DESCRIPTION
This PR closes #340.

### How was it before?

- "incorporar" would always appear

### What has changed?

- now it appears only on desktops

### What should I pay attention when reviewing this PR?

Nothing in particular.

### Is this PR dangerous?

No.