### PR TITLE
TEMP FIX using cycle final date to calculate remaining days (Issue 343)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* [PR #344]: TEMP FIX using cycle final date to calculate remaining days (Issue 343)
+
 ## [1.13.0] - 12/04/2017
 
 * [PR #341]: Hide “incorporar” share if not on a desktop (Issue 340)

--- a/app/models/phase.rb
+++ b/app/models/phase.rb
@@ -84,7 +84,9 @@ class Phase < ActiveRecord::Base
   end
 
   def remaining_days
-    [0, (final_date.to_date - Date.today).to_i].max
+    # TEMPFIX: revert this commit after the mobile fix
+    date = cycle.final_date.to_date - 1.day
+    [0, (date - Date.today).to_i].max
   end
 
   # validates_attachment :picture, presence: true, content_type: { content_type: ['image/jpeg', 'image/gif', 'image/png', 'image/jpg'] }


### PR DESCRIPTION
This PR closes #343.

This s a TEMPFIX and should be revert after the mobile app is updated.