### PR TITLE
Revert TEMPFIX hack (issue 347)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* [PR #348]: Revert TEMPFIX hack (issue 347)
+
 ## [1.13.1] - 12/04/2017
 
 * [PR #344]: TEMP FIX using cycle final date to calculate remaining days (Issue 343)

--- a/app/controllers/api/v2/entities/cycle.rb
+++ b/app/controllers/api/v2/entities/cycle.rb
@@ -12,7 +12,7 @@ module Api
         expose :color
         expose :description
 
-        with_options format_with: :iso_date do
+        with_options format_with: :iso_date_time do
           expose :initial_date
           expose :final_date
         end
@@ -55,12 +55,12 @@ module Api
 
           property :initial_date do
             key :type, :string
-            format "ISO date"
+            format "ISO date time"
           end
 
           property :final_date do
             key :type, :string
-            format "ISO date"
+            format "ISO date time"
           end
 
           property :pictures do

--- a/app/models/phase.rb
+++ b/app/models/phase.rb
@@ -84,9 +84,7 @@ class Phase < ActiveRecord::Base
   end
 
   def remaining_days
-    # TEMPFIX: revert this commit after the mobile fix
-    date = cycle.final_date.to_date - 1.day
-    [0, (date - Date.today).to_i].max
+    [0, (final_date.to_date - Date.today).to_i].max
   end
 
   # validates_attachment :picture, presence: true, content_type: { content_type: ['image/jpeg', 'image/gif', 'image/png', 'image/jpg'] }


### PR DESCRIPTION
This PR closes #347.

### How was it before?

- there was a hack that calculated the petition remaining days wrong because of an issue with the mobile

### What has changed?

- instead of using this hack, we now just returns the cycle dates with times. This will allow the older mobile versions to calculate the dates correctly

### What should I pay attention when reviewing this PR?

Nothing in particular.

### Is this PR dangerous?

No.