### PR TITLE
Redirect temporarily `envie-sua-ideia` (Issue 355)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* [PR #356]: Redirect temporarily `envie-sua-ideia` (Issue 355)
+
 ## [1.14.0] - 26/04/2017
 
 * [PR #352]: Add scope coverage (nationwide, statewide, citywide) to the petition (Issue 345)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -139,7 +139,7 @@ Rails.application.routes.draw do
     get :sub_profiles
   end
 
-  get "/envie-sua-idea", to: redirect("https://itsrio2.typeform.com/to/nGzwjv", status: 302)
+  get "/envie-sua-ideia", to: redirect("https://itsrio2.typeform.com/to/nGzwjv", status: 302)
 
   match '/busca', to: 'search#show', as: :search, via: :get
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -139,6 +139,8 @@ Rails.application.routes.draw do
     get :sub_profiles
   end
 
+  get "/envie-sua-idea", to: redirect("https://itsrio2.typeform.com/to/nGzwjv", status: 302)
+
   match '/busca', to: 'search#show', as: :search, via: :get
 
   resources :blog_posts, path: 'blog'


### PR DESCRIPTION
This PR closes #355 .

### How was it before?

- there was no link point to the site which the user could follow to the support area

### What has changed?

- now `/envie-sua-ideia` redirects temporarily to typeform support area

### What should I pay attention when reviewing this PR?

Nothing in particular.

### Is this PR dangerous?

No.