### PR TITLE
Redirect “/ajuda” to the help form (Issue 357)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR #358]: Redirect “/ajuda” to the help form (Issue 357)
 * [PR #356]: Redirect temporarily `envie-sua-ideia` (Issue 355)
 
 ## [1.14.0] - 26/04/2017

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -139,7 +139,9 @@ Rails.application.routes.draw do
     get :sub_profiles
   end
 
-  get "/envie-sua-ideia", to: redirect("https://itsrio2.typeform.com/to/nGzwjv", status: 302)
+  help_form_url = "https://itsrio2.typeform.com/to/nGzwjv"
+  get "/envie-sua-ideia", to: redirect(help_form_url, status: 302)
+  get "/ajuda", to: redirect(help_form_url, status: 302)
 
   match '/busca', to: 'search#show', as: :search, via: :get
 


### PR DESCRIPTION
This PR closes #357.

### How was it before?

- mudamos app needed to access `/ajuda` and there was not such route

### What has changed?

- added a redirect from "/ajuda" to "https://itsrio2.typeform.com/to/nGzwjv"

### What should I pay attention when reviewing this PR?

Nothing in particular.

### Is this PR dangerous?

No.