### PR TITLE
Remove your account (Issue 349)

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -4,6 +4,8 @@
 #
 FOG_PROVIDER=Local
 FOG_HOST=//localhost:3000
+
+MOBILE_API_URL=https://blockchain-api.test
 #
 # MUDAMOS_DATABASE_URL=
 # MUDAMOS_DATABASE_HOST=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR #360]: Remove your account (Issue 349)
 * [PR #359]: New favicon (no optimizations) (Issue 224)
 * [PR #358]: Redirect “/ajuda” to the help form (Issue 357)
 * [PR #356]: Redirect temporarily `envie-sua-ideia` (Issue 355)

--- a/app/assets/javascripts/application.coffee
+++ b/app/assets/javascripts/application.coffee
@@ -40,6 +40,7 @@
 #= require inputs/date_mask
 #= require inputs/image_upload
 #= require users/login
+#= require users/remove-account
 #= require dotdotdot-comments
 #= require comments
 #= require search

--- a/app/assets/javascripts/users/remove-account.js
+++ b/app/assets/javascripts/users/remove-account.js
@@ -1,0 +1,46 @@
+(function($, document) {
+  "use strict";
+
+  $(document).ready(function() {
+    var $form = $("#remove_account_form");
+    var $modal = $("#modal_remove_account");
+
+    $("body").on("click", ".remove-account", function(e) {
+      e.preventDefault();
+
+      $modal.modal("show");
+    });
+
+    function validateForm() {
+      var email = $form.find("input[type='email']").val().trim() !== "";
+      var valid = email;
+      $form.find("button[type=submit]").attr("disabled", !valid);
+    }
+
+    $modal.on("hidden.bs.modal", function() {
+      $modal.find(".result .success, .result .error").text("");
+      $modal.find(".modal-footer").addClass("hidden");
+      $form.show();
+    });
+
+    $form
+      .on("ajax:beforeSend", function() {
+        document.start_loading();
+        $(this).closest(".modal-body").find(".result .error").text("");
+      })
+      .on("ajax:complete", function() {
+        document.stop_loading();
+      })
+      .on("ajax:success", function(event, data) {
+        $(this).closest(".modal-body").find(".result .success").text(data.message);
+        $(this).find("input[type='email']").val("");
+        $modal.find(".modal-footer").removeClass("hidden");
+        $form.slideUp();
+      })
+      .on("ajax:error", function() {
+        $(this).closest(".modal-body").find(".result .error").text("Houve um erro. Por favor tente novamente mais tarde.");
+      })
+      .find("input[type='email']")
+        .on("keyup", validateForm);
+  });
+})(jQuery, document);

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -16,6 +16,7 @@
  *= require select2
  *= require_tree ./petition
  *= require_tree ./cycle
+ *= require_tree ./users
  *= require signature
  *= require simple_navbar
  *= require global

--- a/app/assets/stylesheets/users/remove-account.sass
+++ b/app/assets/stylesheets/users/remove-account.sass
@@ -1,0 +1,3 @@
+#modal_remove_account
+  .result
+    margin-bottom: 15px

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,10 +17,11 @@ module ApplicationHelper
   def input f, attribute, options = {}
     m = f.object.class.to_s.underscore
 
+    value = options[:value] || f.object && f.object.send(attribute)
     input_options = {
       autocomplete: :off,
-      html: { value: options[:value] || f.object.send(attribute) },
-      value: options[:value] || f.object.send(attribute)
+      html: { value: value },
+      value: value
     }
 
     if options[:class]

--- a/app/use_cases/petition_plugin/account_remover.rb
+++ b/app/use_cases/petition_plugin/account_remover.rb
@@ -1,0 +1,18 @@
+module PetitionPlugin
+  class AccountRemover
+    Result = Struct.new(:success)
+
+    attr_accessor :service
+
+    def initialize(service: MobileApiService.new)
+      @service = service
+    end
+
+    def perform(email:)
+      service.remove_account email: email
+      Result.new(true)
+    rescue MobileApiService::ValidationError
+      Result.new
+    end
+  end
+end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -47,6 +47,8 @@ html
         = render 'layouts/shared/footer'
 
     .modal-container
+      = render "layouts/shared/modal", modal_id: 'modal_remove_account', size: 'sm', cache: true, content: render(file: "layouts/shared/_remove_account")
+
       - unless user_signed_in?
         = render 'layouts/shared/modal', modal_id: 'modal-session-new', size: 'sm', cache: true, content: render(file: 'users/sessions/new')
         = render 'layouts/shared/modal', modal_id: 'modal-session-login', size: 'sm', cache: true, content: render(file: 'users/sessions/login')

--- a/app/views/layouts/shared/_footer.html.slim
+++ b/app/views/layouts/shared/_footer.html.slim
@@ -10,6 +10,8 @@ nav.navbar.footer-nav
         li= link_to 'Críticas e Sugestões', cycle_blog_post_path(@cycle, BlogPost.find('sobre-a-ombudsperson-silvia-ramos'))
       li= link_to 'Créditos', credits_path
       li= link_to 'Contato', 'mailto:contato@mudamos.org'
+      li
+        a.remove-account href="#" Remover conta
   .container
     hr
   .container

--- a/app/views/layouts/shared/_remove_account.html.slim
+++ b/app/views/layouts/shared/_remove_account.html.slim
@@ -1,0 +1,23 @@
+.modal-body
+  .row
+    .col-xs-12
+      span Remova sua conta da Mudamos+
+  .row.dividers
+    .col-xs-12
+      hr
+
+  .row.result
+    .col-xs-12
+      span.error
+      span.success
+
+  = semantic_form_for "user", url: remove_account_users_path, html: { id: "remove_account_form", class: "row", novalidate: nil }, remote: true do |f|
+    = f.inputs class: "col-xs-12" do
+      = input f, :email, as: :email, label: "Email"
+
+    .col-xs-12
+      button.rounded-button.new type="submit" disabled="disabled" Enviar
+
+.modal-footer.hidden
+  .col-xs-12
+    button.rounded-button.new type="button" data-dismiss="modal" Fechar

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -237,3 +237,7 @@ pt-BR:
   mailer:
     pre_signature:
       subject: "Pré assinatura feita com sucesso!"
+
+  actions:
+    remove_account:
+      success: Você receberá um e-mail com um link para confirmar a sua ação. Verifique a caixa de entrada.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -133,6 +133,7 @@ Rails.application.routes.draw do
 
   resources :users, only: [:update, :me] do
     get :me, on: :collection
+    post :remove_account, on: :collection
   end
 
   resources :profiles, only: [:index, :sub_profiles] do

--- a/spec/services/mobile_api_service_spec.rb
+++ b/spec/services/mobile_api_service_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe MobileApiService do
+
+  describe "#remove_account" do
+    let(:email) { "le@email" }
+    let(:response) do
+      { status: "success" }
+    end
+
+    let(:connection) do
+      Faraday.new do |builder|
+        builder.adapter :test do |stub|
+          stub.post("/api/v1/users/remove/account", JSON.dump(user: { email: email })) do |env|
+            [200, {}, JSON.dump(response)]
+          end
+        end
+      end
+    end
+
+    let(:service) { described_class.new }
+
+    before do
+      service.connection = connection
+    end
+
+    subject { service.remove_account email: email }
+
+    it_behaves_like "a successfull mobile api response"
+
+    context "when validation error" do
+      let(:response) do
+        { status: "fail", data: { errorCode: 666 } }
+      end
+
+      it_behaves_like "an error mobile api response", MobileApiService::ValidationError
+    end
+
+    context "when invalid request" do
+      let(:response) do
+        { status: "error" }
+      end
+
+      it_behaves_like "an error mobile api response", MobileApiService::InvalidRequest
+    end
+  end
+end

--- a/spec/support/shared_examples/services/mobile_api_response.rb
+++ b/spec/support/shared_examples/services/mobile_api_response.rb
@@ -1,0 +1,8 @@
+RSpec.shared_examples_for "a successfull mobile api response" do |code|
+  it { expect { subject }.not_to raise_error }
+end
+
+RSpec.shared_examples_for "an error mobile api response" do |error|
+  it { expect { subject }.to raise_error error }
+end
+

--- a/spec/use_cases/petition_plugin/account_remover_spec.rb
+++ b/spec/use_cases/petition_plugin/account_remover_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe PetitionPlugin::AccountRemover do
+  let(:use_case) { described_class.new }
+
+  its(:service) { is_expected.to be_a MobileApiService }
+
+  describe "#perform" do
+    let(:service) { instance_spy MobileApiService }
+    let(:email) { "le@email.com" }
+
+    let(:use_case) { described_class.new service: service }
+
+    before { allow(service).to receive(:remove_account).with(email: email) }
+
+    subject { use_case.perform email: email }
+
+    its(:success) { is_expected.to be }
+
+    it do
+      subject
+      expect(service).to have_received(:remove_account).with(email: email)
+    end
+
+    context "when a validation error occurs" do
+      before do
+        allow(service).to receive(:remove_account).with(email: email)
+          .and_raise MobileApiService::ValidationError.new("error", [])
+      end
+
+      its(:success) { is_expected.not_to be }
+    end
+  end
+end


### PR DESCRIPTION
This PR closes #349.

### How was it before?

- there was no way users could remove their Mudamos+ (app) account

### What has changed?

- added a link to the footer, which triggers an account removal
- mobile api is called with the user email. They will handle the account removal
- users will then receive an email with instructions (no our responsibility)

### What should I pay attention when reviewing this PR?

Service.

### Is this PR dangerous?

No.

![screenshot 2017-05-08 15 14 16](https://cloud.githubusercontent.com/assets/252061/25818900/85ac34c0-3402-11e7-910f-c9260464667e.png)
![screenshot 2017-05-08 15 26 14](https://cloud.githubusercontent.com/assets/252061/25818961/c6e6156e-3402-11e7-99a5-5238ed5dc697.png)
![screenshot 2017-05-08 15 26 23](https://cloud.githubusercontent.com/assets/252061/25818962/c6e96dcc-3402-11e7-96e9-20bab24f87ce.png)
