### PR TITLE
Auto increase the signatures goal (Issue 346)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR #361]: Auto increase the signatures goal (Issue 346)
 * [PR #360]: Remove your account (Issue 349)
 * [PR #359]: New favicon (no optimizations) (Issue 224)
 * [PR #358]: Redirect “/ajuda” to the help form (Issue 357)

--- a/app/assets/stylesheets/embedded/petitions.sass
+++ b/app/assets/stylesheets/embedded/petitions.sass
@@ -95,7 +95,7 @@ body
       font-size: 14px
       font-weight: 300
       line-height: 18px
-      height: 240px
+      height: 225px
       overflow-y: scroll
       color: rgba(78 ,78 ,78, 0.85)
       margin: 16px 16px 0px 16px
@@ -106,8 +106,16 @@ body
 
     .petition-bottom-information
       display: none
-      height: 35px
+      height: 50px
       padding: 16px 17px 0px 17px
+
+      .final-goal
+        clear: both
+        margin-top: 6px
+        text-align: center
+
+        small
+          font-size: x-small
 
       .petition-period-information
         float: left

--- a/app/controllers/admin/cycles/plugin_relations/petitions_controller.rb
+++ b/app/controllers/admin/cycles/plugin_relations/petitions_controller.rb
@@ -57,7 +57,16 @@ class Admin::Cycles::PluginRelations::PetitionsController < Admin::ApplicationCo
 
   def petition_params
     params.require(:petition_plugin_detail)
-      .permit(:call_to_action, :signatures_required, :presentation, :video_id, :scope_coverage, :city_id, :uf)
+      .permit(%i(
+        call_to_action
+        initial_signatures_goal
+        signatures_required
+        presentation
+        video_id
+        scope_coverage
+        city_id
+        uf
+      ))
   end
 
   def petition_body

--- a/app/services/petition_service.rb
+++ b/app/services/petition_service.rb
@@ -11,12 +11,40 @@ class PetitionService
     @petition_repository = petition_repository
   end
 
-  def fetch_petition_info(petition_id, fresh: false)
-    cache_key = "mobile_petition_info:#{petition_id}"
+  PetitionInfo = Struct.new(
+    :updated_at,
+    :signatures_count,
+    :blockchain_address,
+    :initial_signatures_goal,
+    :total_signatures_required,
+    :current_signatures_goal,
+  )
+  def fetch_petition_info_with(petition:, fresh: false)
+    cache_key = "mobile_petition_info:v2:#{petition.id}"
 
-    Rails.cache.fetch(cache_key, force: fresh) do
-      mobile_service.petition_info(petition_id)
+    info = Rails.cache.fetch(cache_key, force: fresh) do
+      mobile_service.petition_info(petition.id)
     end
+
+    current_signatures_goal = compute_current_signatures_goal(
+      signatures_count: info.signatures_count,
+      initial_signatures_goal: petition.initial_signatures_goal,
+      total_signatures_required: petition.signatures_required
+    )
+
+    PetitionInfo.new(
+      info.updated_at,
+      info.signatures_count,
+      info.blockchain_address,
+      petition.initial_signatures_goal,
+      petition.signatures_required,
+      current_signatures_goal
+    )
+  end
+
+  def fetch_petition_info(petition_id, fresh: false)
+    petition = petition_repository.find_by_id!(petition_id)
+    fetch_petition_info_with petition: petition, fresh: fresh
   end
 
   def fetch_petition_signers(petition_id, limit, fresh: false)
@@ -58,5 +86,12 @@ class PetitionService
         Array.new
       end
     end
+  end
+
+  def compute_current_signatures_goal(signatures_count:, initial_signatures_goal:, total_signatures_required:)
+    signatures_count ||= 0
+    current_signatures_goal = ((signatures_count / initial_signatures_goal) + 1) * initial_signatures_goal
+
+    [current_signatures_goal, total_signatures_required].min
   end
 end

--- a/app/views/admin/cycles/plugin_relations/petitions/_form.html.slim
+++ b/app/views/admin/cycles/plugin_relations/petitions/_form.html.slim
@@ -2,11 +2,14 @@
   .row
     .col-xs-6
       = f.input :call_to_action, label: 'Chamada para ação'
-  .row
-    .col-xs-6
-      = f.input :signatures_required, as: :number, label: 'Número de assinaturas necessárias'
     .col-xs-6
       = f.input :video_id
+  .row
+    .col-xs-6
+      = f.input :initial_signatures_goal, as: :number
+    .col-xs-6
+      = f.input :signatures_required, as: :number
+
   .row.scopes
     .col-xs-12
       = f.input :scope_coverage, as: :radio, collection: PetitionPlugin::Detail::SCOPE_COVERAGES.map { |v| [@petition.class.translate_scope_coverage(v), v] }

--- a/app/views/admin/cycles/plugin_relations/petitions/index.html.slim
+++ b/app/views/admin/cycles/plugin_relations/petitions/index.html.slim
@@ -25,8 +25,14 @@
     .col-xs-6
       .card-module
         .title
-          h3 Número de assinaturas necessárias
-        = @petition.signatures_required
+          h3= @petition.class.human_attribute_name(:signatures_required)
+        = number_with_delimiter @petition.signatures_required
+    .col-xs-6
+      .card-module
+        .title
+          h3= @petition.class.human_attribute_name(:initial_signatures_goal)
+        = number_with_delimiter @petition.initial_signatures_goal
+  .row
     .col-xs-6
       .card-module
         .title

--- a/app/views/cycles/plugin_relations/petition.html.slim
+++ b/app/views/cycles/plugin_relations/petition.html.slim
@@ -41,8 +41,13 @@ section#petition-index
           .col-xs-12.progress-description
             | Faltam
             strong.remaining-signatures
-            | assinaturas para a meta de
-            strong=" #{@petition.signatures_required}"
+            | assinaturas para a meta de&nbsp;
+            strong.current-goal
+          .col-xs-12.final-goal
+            small
+              | Nossa meta final é de
+              strong<>= @petition.signatures_required
+              small assinaturas
 
           - if @phase.in_progress?
             .col-lg-12.col-sm-6.col-xs-12.remaining-days.bottom-info-container
@@ -50,7 +55,7 @@ section#petition-index
               div.medium-padded
                 - if @phase.remaining_days > 0
                   strong>= "#{@phase.remaining_days} #{@phase.remaining_days > 1 ? "dias" : "dia"}"
-                  .visible-lg-inline= "#{@phase.remaining_days > 1 ? "restantes" : "restante"} para o atingimento da meta final"
+                  .visible-lg-inline= "#{@phase.remaining_days > 1 ? "restantes" : "restante"} para o atingimento da meta"
                 - else
                   strong Último dia
               div.medium-padded.subtitle
@@ -104,6 +109,11 @@ section#petition-index
           .col-xs-6.text-right.signatures
             .total-signatures
             div
+              small assinaturas
+            div style="margin-top: 6px"
+              small>
+                | Nossa meta final é de
+                strong<>= @petition.signatures_required
               small assinaturas
 
         .row#petition-signers-desktop.signatures-list.visible-lg-block
@@ -179,17 +189,17 @@ javascript:
       });
 
       function updatePetitionInfo() {
-        var signaturesRequired = "#{@petition.signatures_required}";
-
         apiClient.getPetitionInfo(#{@petition.id}).then(function(petitionInfo) {
           if (petitionInfo) {
             var count = petitionInfo.signatures_count;
+            var currentGoal = petitionInfo.current_signatures_goal;
 
-            var percentage = (count / signaturesRequired) * 100;
+            var percentage = (count / currentGoal) * 100;
             $(".petition-signatures-progress").trigger("update", percentage + "%");
             $(".already-signed strong").text(count + " ");
-            $(".remaining-signatures").text(" " + (signaturesRequired - count) + " ");
-            $(".phone-bottom-info .total-signatures").text(count + " de " + signaturesRequired);
+            $(".remaining-signatures").text(" " + (currentGoal - count) + " ");
+            $(".phone-bottom-info .total-signatures").text(count + " de " + currentGoal);
+            $(".progress-description .current-goal").text(currentGoal);
           }
         });
       }

--- a/app/views/embedded/petitions/show.html.slim
+++ b/app/views/embedded/petitions/show.html.slim
@@ -27,9 +27,14 @@ html
             div para o encerramento
         div.petition-signatures-information
           div#signatures_count
-            span 0
-            =" de #{petition.signatures_required}"
+            span 0 de 0
           div assinaturas
+        div.final-goal
+          small>
+            | Nossa meta final é de
+            strong<>= petition.signatures_required
+          small assinaturas
+
       div.petition-button-container
         = link_to generate_link, target: "_parent" do
           button style="background-color: #{cycle.color}"
@@ -48,18 +53,18 @@ javascript:
     }
 
     function updateSignaturesCount() {
-      var signaturesRequired = "#{petition.signatures_required}";
-
       apiClient.getPetitionInfo(#{petition.id}).then(function(petitionInfo) {
         if (petitionInfo) {
           var count = petitionInfo.signatures_count;
+          var currentGoal = petitionInfo.current_signatures_goal;
+          var message = count + " de " + currentGoal;
 
-          var percentage = (count / signaturesRequired) * 100;
+          var percentage = (count / currentGoal) * 100;
           $(".petition-progress").css("width", percentage + "%");
 
-          $("#signatures_count span").text(count);
+          $("#signatures_count span").text(message);
 
-          $(".petition-progress-container").attr("title", count + " de " + signaturesRequired + " assinaturas")
+          $(".petition-progress-container").attr("title", message + " assinaturas")
         }
       });
     }

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -218,11 +218,14 @@ pt-BR:
         plugin_relation: Relacionamento do plugin
       petition_plugin/detail:
         city: Cidade
+        current_signatures_goal: Meta atual de assinaturas
+        initial_signatures_goal: Meta inicial de assinaturas
         scope_coverage: Abrangência
         scope_coverages:
           nationwide: Nacional
           statewide: Estadual
           citywide: Municipal
+        signatures_required: Meta final de assinaturas
         uf: Estado
         video_id: Id do vídeo do YouTube
     models:

--- a/db/migrate/20170509115010_add_initial_signatures_goal_to_petition_details.rb
+++ b/db/migrate/20170509115010_add_initial_signatures_goal_to_petition_details.rb
@@ -1,0 +1,5 @@
+class AddInitialSignaturesGoalToPetitionDetails < ActiveRecord::Migration
+  def change
+    add_column :petition_plugin_details, :initial_signatures_goal, :integer, null: false, default: 10_000
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170417195810) do
+ActiveRecord::Schema.define(version: 20170509115010) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -357,17 +357,18 @@ ActiveRecord::Schema.define(version: 20170417195810) do
   add_index "petition_plugin_detail_versions", ["petition_plugin_detail_id"], name: "idx_petition_plg_detail_versions_on_petition_plg_detail_id", using: :btree
 
   create_table "petition_plugin_details", force: :cascade do |t|
-    t.integer  "plugin_relation_id",                         null: false
+    t.integer  "plugin_relation_id",                             null: false
     t.datetime "deleted_at"
-    t.datetime "created_at",                                 null: false
-    t.datetime "updated_at",                                 null: false
-    t.string   "call_to_action",                             null: false
-    t.integer  "signatures_required",                        null: false
-    t.text     "presentation",                               null: false
+    t.datetime "created_at",                                     null: false
+    t.datetime "updated_at",                                     null: false
+    t.string   "call_to_action",                                 null: false
+    t.integer  "signatures_required",                            null: false
+    t.text     "presentation",                                   null: false
     t.string   "video_id"
     t.integer  "city_id"
-    t.string   "scope_coverage",      default: "nationwide", null: false
+    t.string   "scope_coverage",          default: "nationwide", null: false
     t.string   "uf"
+    t.integer  "initial_signatures_goal", default: 10000,        null: false
   end
 
   add_index "petition_plugin_details", ["city_id"], name: "index_petition_plugin_details_on_city_id", using: :btree

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -56,6 +56,8 @@ RSpec.configure do |config|
   config.include Paperclip::Shoulda::Matchers
   config.include Devise::TestHelpers, :type => :controller
   config.include WithEnvHelper
+
+  config.before { Rails.cache.clear }
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/services/petition_service_spec.rb
+++ b/spec/services/petition_service_spec.rb
@@ -1,0 +1,100 @@
+require "rails_helper"
+
+RSpec.describe PetitionService do
+  let(:service) { described_class.new }
+  let(:mobile_service) { instance_spy MobileApiService }
+  let(:petition_repository) { instance_spy PetitionPlugin::DetailRepository }
+
+  its(:mobile_service) { is_expected.to be_a MobileApiService }
+  its(:petition_repository) { is_expected.to be_a PetitionPlugin::DetailRepository }
+
+  describe "#fetch_petition_info_with" do
+    let(:service) { described_class.new mobile_service: mobile_service }
+    let(:fresh) { true }
+    let(:petition) do
+      double :petition_detail, id: 666, initial_signatures_goal: 10, signatures_required: 100
+    end
+
+    let(:api_info) do
+      MobileApiService::PetitionInfo.new(Time.current, 4, "blockaddress")
+    end
+
+    before do
+      allow(mobile_service).to receive(:petition_info).and_return api_info
+    end
+
+    subject { service.fetch_petition_info_with petition: petition, fresh: fresh }
+
+    its(:updated_at) { is_expected.to eq api_info.updated_at }
+    its(:signatures_count) { is_expected.to eq api_info.signatures_count }
+    its(:blockchain_address) { is_expected.to eq api_info.blockchain_address }
+    its(:initial_signatures_goal) { is_expected.to eq petition.initial_signatures_goal }
+    its(:total_signatures_required) { is_expected.to eq petition.signatures_required }
+    its(:current_signatures_goal) { is_expected.to eq 10 }
+
+    context "when not fresh but cached" do
+      let(:fresh) { false }
+
+      before { Rails.cache.write "mobile_petition_info:v2:#{petition.id}", api_info }
+
+      it do
+        subject
+        expect(mobile_service).to_not have_received(:petition_info)
+      end
+    end
+  end
+
+  describe "#fetch_petition_info" do
+    let(:service) { described_class.new petition_repository: petition_repository }
+    let(:fresh) { true }
+    let(:petition) { double :petition_detail, id: 666 }
+    let(:api_info) { double }
+
+    before do
+      allow(service).to receive(:fetch_petition_info_with)
+        .with(petition: petition, fresh: fresh)
+        .and_return api_info
+
+      allow(petition_repository).to receive(:find_by_id!)
+        .with(petition.id)
+        .and_return petition
+    end
+
+    subject { service.fetch_petition_info petition.id, fresh: fresh }
+
+    it { is_expected.to eq api_info }
+  end
+
+  describe "#compute_current_signatures_goal" do
+    let(:signatures_count) { 10 }
+    let(:initial_signatures_goal) { 20 }
+    let(:total_signatures_required) { 100 }
+
+    subject do
+      service.compute_current_signatures_goal signatures_count: signatures_count,
+                                              initial_signatures_goal: initial_signatures_goal,
+                                              total_signatures_required: total_signatures_required
+    end
+
+    it "is the initial goal" do
+      is_expected.to eq initial_signatures_goal
+    end
+
+    context "when the signatures count is equal the goal" do
+      let(:signatures_count) { 20 }
+      it { is_expected.to eq initial_signatures_goal * 2 }
+    end
+
+    signatures_count = (25..100).step(20)
+    expected_goal = (40..100).step(20).to_a
+    signatures_count.each_with_index do |count, index|
+      context "when the count increases and pass the current goal" do
+        let(:signatures_count) { count }
+
+        it "doubles the initial goal" do
+          is_expected.to eq expected_goal[index]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR closes #346.

### How was it before?

- the signatures required were fixed
- the admin had to manually increase it

### What has changed?

- now we introduce a `initial signatures goal`. The `#signatures_required` should be interpreted as the final goal
- when the current number of signatures is over the current goal, say the initial, the current goal must double itself until reaching the final goal

### What should I pay attention when reviewing this PR?

The services which provide the information.

### Is this PR dangerous?

No.

![screenshot 2017-05-10 14 05 09](https://cloud.githubusercontent.com/assets/252061/25953191/ff0ba85e-3638-11e7-9530-0e7447381f78.png)
![screenshot 2017-05-10 14 05 25](https://cloud.githubusercontent.com/assets/252061/25953192/ff10127c-3638-11e7-9862-52a106dcff25.png)
![screenshot 2017-05-10 14 05 39](https://cloud.githubusercontent.com/assets/252061/25953193/ff16f97a-3638-11e7-8bfe-c907eef7e020.png)
