### PR TITLE
Expose plip signature goals (Issue 363)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR #368]: Expose plip signature goals (Issue 363)
 * [PR #367]: Changes the current goal algorithm to increase by a 25% ratio (Issue 365)
 * [PR #366]: Change petition days remaining message (Issue 364)
 

--- a/app/controllers/api/v2/entities/plip.rb
+++ b/app/controllers/api/v2/entities/plip.rb
@@ -11,6 +11,8 @@ module Api
         expose :plip_url
         expose :content
         expose :presentation
+        expose :initial_signatures_goal
+        expose :total_signatures_required
         expose :signatures_required
         expose :call_to_action
         expose :video_id
@@ -36,8 +38,16 @@ module Api
             key :type, :string
           end
 
+          property :initial_signatures_goal do
+            key :type, :integer
+          end
+
           property :signatures_required do
-            key :type, :string
+            key :type, :integer
+          end
+
+          property :total_signatures_required do
+            key :type, :integer
           end
 
           property :call_to_action do

--- a/app/models/plip.rb
+++ b/app/models/plip.rb
@@ -1,9 +1,17 @@
 class Plip
   extend Forwardable
 
-  def_delegators :detail, :published_version, :presentation, :signatures_required, :call_to_action, :video_id, :uf, :city
+  def_delegators :detail, :published_version,
+                          :presentation,
+                          :call_to_action,
+                          :video_id,
+                          :uf,
+                          :city
   def_delegators :published_version, :id, :document_url
   def_delegators :phase, :cycle
+
+  def_delegators :petition_info, :total_signatures_required,
+                                 :initial_signatures_goal
 
   ScopeCoverage = Struct.new(:scope, :uf, :city)
 
@@ -19,10 +27,15 @@ class Plip
   #   @return [String]
   attr_accessor :plip_url
 
-  def initialize(detail:, phase:, plip_url:)
+  # @!attribute [rw] petition_service
+  #   @return [PetitionService]
+  attr_accessor :petition_service
+
+  def initialize(detail:, phase:, plip_url:, petition_service: PetitionService.new)
     @detail = detail
     @phase = phase
     @plip_url = plip_url
+    @petition_service = petition_service
   end
 
   def content
@@ -31,5 +44,13 @@ class Plip
 
   def scope_coverage
     ScopeCoverage.new(detail.scope_coverage, detail.uf, detail.city)
+  end
+
+  def signatures_required
+    petition_info.current_signatures_goal
+  end
+
+  def petition_info
+    @petition_info ||= petition_service.fetch_petition_info_with(petition: detail)
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -6,6 +6,8 @@ Rails.application.configure do
   # since you don't have to restart the web server when you make code changes.
   config.cache_classes = false
 
+  config.cache_store = :dalli_store, ENV["MEMCACHED_HOST"] if ENV["MEMCACHED_HOST"]
+
   # Do not eager load code on boot.
   config.eager_load = false
 


### PR DESCRIPTION
This PR closes #363 

### How was it before?

- the plips api exposed `signatures_required` as a final goal

### What has changed?

- now it represents the current goal
- we expose the final and initial goal

### What should I pay attention when reviewing this PR?

Nothing in particular.

### Is this PR dangerous?

No.