### PR TITLE
Format the plip’s metrics (Issue 369)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [1.16.0] - 15/05/2017
 
+* [PR #370]: Format the plip’s metrics (Issue 369)
 * [PR #368]: Expose plip signature goals (Issue 363)
 * [PR #367]: Changes the current goal algorithm to increase by a 25% ratio (Issue 365)
 * [PR #366]: Change petition days remaining message (Issue 364)

--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ gem 'slim-rails'
 
 gem 'awesome_nested_set'
 gem "select2-rails"
+gem 'rails-assets-numeraljs', source: 'https://rails-assets.org'
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,6 @@
 GEM
   remote: http://rubygems.org/
+  remote: https://rails-assets.org/
   specs:
     CFPropertyList (2.3.2)
     actionmailer (4.2.3)
@@ -445,6 +446,7 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 4.2.3)
       sprockets-rails
+    rails-assets-numeraljs (2.0.6)
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
     rails-dom-testing (1.0.7)
@@ -658,6 +660,7 @@ DEPENDENCIES
   pry-rails
   rack-cors
   rails (= 4.2.3)
+  rails-assets-numeraljs!
   rails_12factor
   redcarpet
   remotipart

--- a/app/assets/javascripts/application.coffee
+++ b/app/assets/javascripts/application.coffee
@@ -13,6 +13,8 @@
 #= require routes
 #= require jquery
 #= require jquery_ujs
+#= require numeraljs
+#= require numeraljs/locales/pt-br
 #= require jquery.remotipart
 #= require parallax.min
 #= require loading
@@ -66,6 +68,8 @@
 #= require moment.min
 #= require asmcrypto
 #= require home-blocks
+
+numeral.locale "pt-br"
 
 document.expiration_default_time = 300
 

--- a/app/assets/javascripts/embedded/application.js
+++ b/app/assets/javascripts/embedded/application.js
@@ -1,3 +1,7 @@
 //= require jquery
+//= require numeraljs
+//= require numeraljs/locales/pt-br
 //= require ../api
 //= require ../mu.petition-signers
+
+numeral.locale("pt-br");

--- a/app/views/cycles/plugin_relations/petition.html.slim
+++ b/app/views/cycles/plugin_relations/petition.html.slim
@@ -46,7 +46,7 @@ section#petition-index
           .col-xs-12.final-goal
             small
               | Nossa meta final é de
-              strong<>= @petition.signatures_required
+              strong<>= number_with_delimiter @petition.signatures_required
               small assinaturas
 
           - if @phase.in_progress?
@@ -54,13 +54,13 @@ section#petition-index
               i.pull-left.material-icons style="color: #{@cycle.color}" access_time
               div.medium-padded
                 - if @phase.remaining_days > 0
-                  strong>= "#{@phase.remaining_days} #{@phase.remaining_days > 1 ? "dias" : "dia"}"
-                  .visible-lg-inline= "#{@phase.remaining_days > 1 ? "restantes" : "restante"} para o atingimento da meta final"
+                  strong>= "#{number_with_delimiter @phase.remaining_days} #{@phase.remaining_days > 1 ? "dias" : "dia"}"
+                  .visible-lg-inline= "#{@phase.remaining_days > 1 ? "restantes" : "restante"} para atingirmos a meta final"
                 - else
                   strong Último dia
               div.medium-padded.subtitle
                 small.visible-lg-block= "As colaborações podem ser feitas até o dia #{@phase.final_date.strftime("%d/%m/%Y")}"
-                small.hidden-lg para o atingimento da meta final
+                small.hidden-lg para atingirmos a meta final
 
             .col-lg-12.col-sm-6.col-xs-12.download-document.bottom-info-container
               i.pull-left.material-icons style="color: #{@cycle.color}" file_download
@@ -101,11 +101,11 @@ section#petition-index
           - if @phase.in_progress?
             .col-xs-6.progress
               - if @phase.remaining_days > 0
-                strong= "#{@phase.remaining_days} #{@phase.remaining_days > 1 ? "dias restantes" : "dia restante"} "
+                strong= "#{number_with_delimiter @phase.remaining_days} #{@phase.remaining_days > 1 ? "dias restantes" : "dia restante"} "
               - else
                 strong Último dia
               div
-                small para o atingimento da meta final
+                small para atingirmos a meta final
           .col-xs-6.text-right.signatures
             .total-signatures
             div
@@ -113,7 +113,7 @@ section#petition-index
             div style="margin-top: 6px"
               small>
                 | Nossa meta final é de
-                strong<>= @petition.signatures_required
+                strong<>= number_with_delimiter @petition.signatures_required
               small assinaturas
 
         .row#petition-signers-desktop.signatures-list.visible-lg-block
@@ -195,11 +195,13 @@ javascript:
             var currentGoal = petitionInfo.current_signatures_goal;
 
             var percentage = (count / currentGoal) * 100;
+            var nCount = numeral(count);
+            var nCurrentGoal = numeral(currentGoal);
             $(".petition-signatures-progress").trigger("update", percentage + "%");
-            $(".already-signed strong").text(count + " ");
-            $(".remaining-signatures").text(" " + (currentGoal - count) + " ");
-            $(".phone-bottom-info .total-signatures").text(count + " de " + currentGoal);
-            $(".progress-description .current-goal").text(currentGoal);
+            $(".already-signed strong").text(nCount.format() + " ");
+            $(".remaining-signatures").text(" " + numeral(currentGoal - count).format() + " ");
+            $(".phone-bottom-info .total-signatures").text(nCount.format() + " de " + nCurrentGoal.format());
+            $(".progress-description .current-goal").text(nCurrentGoal.format());
           }
         });
       }

--- a/app/views/embedded/petitions/show.html.slim
+++ b/app/views/embedded/petitions/show.html.slim
@@ -23,8 +23,8 @@ html
             div= petition.plugin_relation.related.final_date.strftime("%d/%m/%Y")
             div data de encerramento
           - else
-            div= "#{petition.plugin_relation.related.remaining_days} dias restantes"
-            div para o atingimento da meta final
+            div= "#{number_with_delimiter petition.plugin_relation.related.remaining_days} dias restantes"
+            div para atingirmos a meta final
         div.petition-signatures-information
           div#signatures_count
             span 0 de 0
@@ -32,7 +32,7 @@ html
         div.final-goal
           small>
             | Nossa meta final é de
-            strong<>= petition.signatures_required
+            strong<>= number_with_delimiter petition.signatures_required
           small assinaturas
 
       div.petition-button-container
@@ -57,7 +57,7 @@ javascript:
         if (petitionInfo) {
           var count = petitionInfo.signatures_count;
           var currentGoal = petitionInfo.current_signatures_goal;
-          var message = count + " de " + currentGoal;
+          var message = numeral(count).format() + " de " + numeral(currentGoal).format();
 
           var percentage = (count / currentGoal) * 100;
           $(".petition-progress").css("width", percentage + "%");


### PR DESCRIPTION
This PR closes #369.

### How was it before?

- the plips's metrics data were not formatted

### What has changed?

- now we format them both on the server and client
- added numeral.js dependency

### What should I pay attention when reviewing this PR?

Everything.

### Is this PR dangerous?

No.

![screenshot 2017-05-15 11 10 58](https://cloud.githubusercontent.com/assets/252061/26061932/b71e46d0-395f-11e7-8a14-d955c8a94ae2.png)
![screenshot 2017-05-15 11 11 06](https://cloud.githubusercontent.com/assets/252061/26061934/b7480006-395f-11e7-971a-ab15c6bba328.png)
![screenshot 2017-05-15 11 11 14](https://cloud.githubusercontent.com/assets/252061/26061933/b71fa6b0-395f-11e7-9372-a3d36f4cfa06.png)
