### PR TITLE
Only notify users when it is a nationwide plip (Issue 378)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* [PR #379]: Only notify users when it is a nationwide plip (Issue 378)
+
 ## [1.16.0] - 15/05/2017
 
 * [PR #370]: Format the plip’s metrics (Issue 369)

--- a/app/models/petition_plugin/detail_version.rb
+++ b/app/models/petition_plugin/detail_version.rb
@@ -21,4 +21,6 @@ class PetitionPlugin::DetailVersion < ActiveRecord::Base
   scope :published, -> { where published: true }
 
   validates :body, presence: true
+
+  delegate :nationwide?, :statewide?, :citywide?, to: :petition_plugin_detail
 end

--- a/spec/jobs/petition_publisher_worker_spec.rb
+++ b/spec/jobs/petition_publisher_worker_spec.rb
@@ -1,28 +1,80 @@
 require "rails_helper"
 
 RSpec.describe PetitionPublisherWorker do
+  subject { described_class.new }
 
-  let(:detail_version_repository) { instance_spy PetitionPlugin::DetailVersionRepository }
-  let(:worker) { described_class.new repository: detail_version_repository }
+  its(:repository) { is_expected.to be_a PetitionPlugin::DetailVersionRepository }
+  its(:petition_service) { is_expected.to be_a PetitionService }
+  its(:notifier) { is_expected.to be PetitionNotifierWorker }
 
   describe "#perform" do
-    let(:version) { spy PetitionPlugin::Detail.new, id: 1 }
+    let(:detail_version_repository) { instance_spy PetitionPlugin::DetailVersionRepository }
+    let(:petition_service) { instance_spy PetitionService }
+    let(:notifier) { class_spy PetitionNotifierWorker }
+    let(:worker) { described_class.new repository: detail_version_repository }
+    let(:detail){ spy PetitionPlugin::Detail.new id: 1 }
+    let(:version) do
+      spy PetitionPlugin::DetailVersion.new, id: 2, petition_plugin_detail_id: detail.id
+    end
+    let(:versions) { [version] }
 
-    before do
-      allow(detail_version_repository).to receive(:find_by_id).with(version.id).and_return(version)
+    let(:worker) do
+      described_class.new repository: detail_version_repository,
+                          petition_service: petition_service,
+                          notifier: notifier
     end
 
-    subject { worker.perform nil, "{ \"id\": #{version.id} }" }
+    before do
+      allow(version).to receive(:nationwide?).and_return true
+      allow(version).to receive(:petition_plugin_detail).and_return detail
+      allow(detail).to receive(:petition_detail_versions).and_return versions
+      allow(detail_version_repository).to receive(:find_by_id).with(version.id).and_return(version)
+      allow(petition_service).to receive(:fetch_past_versions)
+        .with(version.petition_plugin_detail_id, fresh: true)
+    end
+
+    subject { worker.perform nil, JSON.dump(id: version.id) }
 
     it "publishes the version" do
       subject
-      expect(version).to have_received(:update).with(published: true)
+      expect(version).to have_received(:update!).with(published: true)
+    end
+
+    it "refreshes the past versions cache" do
+      subject
+      expect(petition_service).to have_received(:fetch_past_versions)
+        .with(version.petition_plugin_detail_id, fresh: true)
+    end
+
+    it "schedules a notification" do
+      subject
+      expect(notifier).to have_received(:perform_async).with id: version.id
     end
 
     context "when the body is invalid" do
       subject { worker.perform nil, "{" }
 
       it { expect { subject }.to raise_error JSON::ParserError }
+    end
+
+    context "when it is not a nationwide plip" do
+      before do
+        allow(version).to receive(:nationwide?).and_return false
+      end
+
+      it do
+        subject
+        expect(notifier).to_not have_received(:perform_async)
+      end
+    end
+
+    context "when it is not the first version" do
+      let(:versions) { [double, double] }
+
+      it do
+        subject
+        expect(notifier).to_not have_received(:perform_async)
+      end
     end
   end
 end


### PR DESCRIPTION
This PR closes #378.

### How was it before?

- users would be notified on all first version plip publication

### What has changed?

- now they are notified if it is a nationwide plip

### What should I pay attention when reviewing this PR?

Nothing in particular.

### Is this PR dangerous?

No.