### PR TITLE
Notify users on all scope coverages (Issue 390)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* [PR #391]: Notify users on all scope coverages (Issue 390)
+
 ## [1.19.0] - 23/08/2017
 
 * [PR #388]: Return lib folder (Issue 387)

--- a/app/jobs/petition_publisher_worker.rb
+++ b/app/jobs/petition_publisher_worker.rb
@@ -38,7 +38,7 @@ class PetitionPublisherWorker
   end
 
   def should_notify_users?(version)
-    version.nationwide? && is_first_version(version)
+    is_first_version(version)
   end
 
   def is_first_version(version)

--- a/spec/jobs/petition_publisher_worker_spec.rb
+++ b/spec/jobs/petition_publisher_worker_spec.rb
@@ -57,17 +57,6 @@ RSpec.describe PetitionPublisherWorker do
       it { expect { subject }.to raise_error JSON::ParserError }
     end
 
-    context "when it is not a nationwide plip" do
-      before do
-        allow(version).to receive(:nationwide?).and_return false
-      end
-
-      it do
-        subject
-        expect(notifier).to_not have_received(:perform_async)
-      end
-    end
-
     context "when it is not the first version" do
       let(:versions) { [double, double] }
 


### PR DESCRIPTION
This PR closes #390.

### What has changed?

- now when creating a new plip, all scope coverages will trigger a user push notification