### PR TITLE
Send petition location to the blockchain api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* [PR xxx]: Send location info to the blockchain api (Issue 392)
+
 ## [1.20.0] - 25/08/2017
 
 * [PR #391]: Notify users on all scope coverages (Issue 390)

--- a/app/services/mobile_api_service.rb
+++ b/app/services/mobile_api_service.rb
@@ -71,7 +71,8 @@ class MobileApiService
   end
 
   def register_petition_version(petition_detail_version)
-    phase = petition_detail_version.petition_plugin_detail.plugin_relation.related
+    petition_plugin_detail = petition_detail_version.petition_plugin_detail
+    phase = petition_plugin_detail.plugin_relation.related
 
     page_url = Rails.application.routes.url_helpers.cycle_plugin_relation_url(
       phase.cycle,
@@ -87,7 +88,10 @@ class MobileApiService
         name: phase.name,
         url: petition_detail_version.document_url,
         page_url: page_url,
-        sha: petition_detail_version.sha
+        sha: petition_detail_version.sha,
+        scope_coverage: petition_plugin_detail.scope_coverage,
+        uf: petition_plugin_detail.uf.presence,
+        city_id: petition_plugin_detail.city_id,
       },
     }, headers)
   end


### PR DESCRIPTION
This PR closes #392.

### How was it before?

- the blockchain api had no access to the petition location

### What has changed?

- now when registering the petition, the location info is sent

### What should I pay attention when reviewing this PR?

- the location is only sent when registering a new petition or version, so if the location info is changed, but not the petition body (text), the blockchain api will have an old location information.

### Is this PR dangerous?

No...no harm.