### PR TITLE
Do not send push message when creating a new plip

### DIFF
--- a/app/jobs/petition_publisher_worker.rb
+++ b/app/jobs/petition_publisher_worker.rb
@@ -4,16 +4,13 @@ class PetitionPublisherWorker
 
   attr_reader :repository
   attr_accessor :petition_service
-  attr_accessor :notifier
 
   def initialize(
     repository: PetitionPlugin::DetailVersionRepository.new,
-    petition_service: PetitionService.new,
-    notifier: PetitionNotifierWorker
+    petition_service: PetitionService.new
   )
     @repository = repository
     @petition_service = petition_service
-    @notifier = notifier
   end
 
   def perform(sqs_msg, body)
@@ -26,23 +23,9 @@ class PetitionPublisherWorker
       Rails.logger.info "Version published #{petition_detail_version_id}"
 
       refresh_caches version
-
-      if should_notify_users? version
-        notifier.perform_async id: version.id
-      else
-        Rails.logger.info "Skipping push message."
-      end
     else
       Rails.logger.warn "Version not found #{petition_detail_version_id}"
     end
-  end
-
-  def should_notify_users?(version)
-    is_first_version(version)
-  end
-
-  def is_first_version(version)
-    version.petition_plugin_detail.petition_detail_versions.count == 1
   end
 
   def refresh_caches(version)

--- a/spec/jobs/petition_publisher_worker_spec.rb
+++ b/spec/jobs/petition_publisher_worker_spec.rb
@@ -5,12 +5,10 @@ RSpec.describe PetitionPublisherWorker do
 
   its(:repository) { is_expected.to be_a PetitionPlugin::DetailVersionRepository }
   its(:petition_service) { is_expected.to be_a PetitionService }
-  its(:notifier) { is_expected.to be PetitionNotifierWorker }
 
   describe "#perform" do
     let(:detail_version_repository) { instance_spy PetitionPlugin::DetailVersionRepository }
     let(:petition_service) { instance_spy PetitionService }
-    let(:notifier) { class_spy PetitionNotifierWorker }
     let(:worker) { described_class.new repository: detail_version_repository }
     let(:detail){ spy PetitionPlugin::Detail.new id: 1 }
     let(:version) do
@@ -20,8 +18,7 @@ RSpec.describe PetitionPublisherWorker do
 
     let(:worker) do
       described_class.new repository: detail_version_repository,
-                          petition_service: petition_service,
-                          notifier: notifier
+                          petition_service: petition_service
     end
 
     before do
@@ -46,24 +43,10 @@ RSpec.describe PetitionPublisherWorker do
         .with(version.petition_plugin_detail_id, fresh: true)
     end
 
-    it "schedules a notification" do
-      subject
-      expect(notifier).to have_received(:perform_async).with id: version.id
-    end
-
     context "when the body is invalid" do
       subject { worker.perform nil, "{" }
 
       it { expect { subject }.to raise_error JSON::ParserError }
-    end
-
-    context "when it is not the first version" do
-      let(:versions) { [double, double] }
-
-      it do
-        subject
-        expect(notifier).to_not have_received(:perform_async)
-      end
     end
   end
 end


### PR DESCRIPTION
This PR closes #393.

### What has changed?

- Now when creating a new plip, a push message is no longer sent to users.