### PR TITLE
Show user location if present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next
 
-* [PR xxx]: Send location info to the blockchain api (Issue 392)
+* [PR 398]: Show user location if present (Issue 397)
+* [PR 395]: Do not send push message when creating a new plip (Issue 393)
+* [PR 394]: Send location info to the blockchain api (Issue 392)
 
 ## [1.20.0] - 25/08/2017
 

--- a/app/assets/javascripts/mu.petition-signers.js
+++ b/app/assets/javascripts/mu.petition-signers.js
@@ -75,10 +75,12 @@
         $row.append($name);
 
         var $signTimeAndLocation = $("<div class='sign-time-and-location'></div>");
-        $signTimeAndLocation.text(
-          capitalizeFirstLetter(jQuery.timeago(new Date(userInfo.date))) + " | " +
-          userInfo.city + " - " + userInfo.uf
-        );
+        var userLocation = userInfo.city && userInfo.uf ? userInfo.city + " - " + userInfo.uf : null;
+        var signTimeText = capitalizeFirstLetter(jQuery.timeago(new Date(userInfo.date)));
+
+        if (userLocation) signTimeText += " | " + userLocation;
+
+        $signTimeAndLocation.text(signTimeText);
         $row.append($signTimeAndLocation);
 
         $element.append($row);


### PR DESCRIPTION
This PR closes #397.

### How was it before?

The plip page would present the signers with "null" information

### What has changed?

Now only if the user has both the city and state, they are going to be presented.

### Is this PR dangerous?

No.