### PR TITLE
Allow creating national cause plips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR 399]: Allow creating national cause plips (Issue 396)
 * [PR 398]: Show user location if present (Issue 397)
 * [PR 395]: Do not send push message when creating a new plip (Issue 393)
 * [PR 394]: Send location info to the blockchain api (Issue 392)

--- a/app/models/petition_plugin/detail.rb
+++ b/app/models/petition_plugin/detail.rb
@@ -35,7 +35,6 @@ class PetitionPlugin::Detail < ActiveRecord::Base
   validates :signatures_required, :initial_signatures_goal, numericality: { greater_than_or_equal_to: 1_000 }
   validates :presentation, presence: true
   validates :scope_coverage, presence: true, inclusion: { in: SCOPE_COVERAGES }
-  validates :city, presence: true, if: -> { scope_coverage == CITYWIDE_SCOPE }
   validates :uf, presence: true, inclusion: { in: UFS }, if: -> { scope_coverage == STATEWIDE_SCOPE }
 
   validate :ensure_scope_coverage_detail
@@ -59,6 +58,10 @@ class PetitionPlugin::Detail < ActiveRecord::Base
     define_method "#{scope}?" do
       scope_coverage == scope
     end
+  end
+
+  def city_cause?
+    scope_coverage === CITYWIDE_SCOPE && city.blank?
   end
 
   # Do not allow setting incorrect scope coverage detail if the wrong scope

--- a/app/views/admin/cycles/plugin_relations/petitions/_form.html.slim
+++ b/app/views/admin/cycles/plugin_relations/petitions/_form.html.slim
@@ -20,6 +20,8 @@
 
   .row.scope-row.cities.citywide
     .col-xs-12
+      = f.input :city_cause?, as: :boolean, input_html: { class: "cause-input citywide" }
+    .col-xs-12
       - city_values = f.object.city.present? ? [["#{f.object.city.name}, #{f.object.city.uf}", f.object.city.id]] : []
       = f.input :city, as: :select, collection: city_values, include_blank: "Selecione a cidade"
 
@@ -39,7 +41,12 @@
     $(document).ready(function() {
       $(".scopes input[type='radio']").on("change", function() {
         $(".scope-row").hide().find("select").val("").trigger("change");
+        $(".cause-input").attr("checked", false);
         $(".row." + $(this).val()).slideDown();
+      });
+
+      $(".cause-input").on("change", function() {
+        $(this).closest(".scope-row").find("select").val("").trigger("change");
       });
 
       $(".row.cities").find("select").select2({

--- a/app/views/admin/cycles/plugin_relations/petitions/index.html.slim
+++ b/app/views/admin/cycles/plugin_relations/petitions/index.html.slim
@@ -57,7 +57,7 @@
         .card-module
           .title
             h3=@petition.class.human_attribute_name :city
-          = @petition.city.name
+          = @petition.city.try(:name) || @petition.class.human_attribute_name(:city_cause?)
 
   .row
     .col-xs-12

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -218,6 +218,7 @@ pt-BR:
         plugin_relation: Relacionamento do plugin
       petition_plugin/detail:
         city: Cidade
+        city_cause?: Causa nacional nos municípios
         current_signatures_goal: Meta atual de assinaturas
         initial_signatures_goal: Meta inicial de assinaturas
         scope_coverage: Abrangência


### PR DESCRIPTION
This PR closes #396.

### What has changed?

- it's now possible to create national cause plips, which means they are `citywide` scope but there is not city attached it