### PR TITLE
Return national causes on the plips api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR 402]: Return national causes on the plips api (citywide) (Issue 400)
 * [PR 399]: Allow creating national cause plips (Issue 396)
 * [PR 398]: Show user location if present (Issue 397)
 * [PR 395]: Do not send push message when creating a new plip (Issue 393)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-* [PR 402]: Return national causes on the plips api (citywide) (Issue 400)
+* [PR 402]: Return national causes on the plips api (Issue 400)
 * [PR 399]: Allow creating national cause plips (Issue 396)
 * [PR 398]: Show user location if present (Issue 397)
 * [PR 395]: Do not send push message when creating a new plip (Issue 393)

--- a/app/controllers/api/v2/plips_controller.rb
+++ b/app/controllers/api/v2/plips_controller.rb
@@ -49,14 +49,14 @@ class Api::V2::PlipsController < Api::V2::ApplicationController
         key :in, :query
         key :description, "Returns plips from the given scope"
         key :type, :list
-        key :enum, %w(nationwide statewide citywide all)
+        key :enum, %w(nationwide statewide citywide all causes)
         key :default, :all
       end
 
       parameter do
-        key :name, :cause
+        key :name, :include_causes
         key :in, :query
-        key :description, "Returns national causes"
+        key :description, "Returns national causes with the given scope"
         key :type, :boolean
       end
 
@@ -88,7 +88,7 @@ class Api::V2::PlipsController < Api::V2::ApplicationController
   def paginated_plips
     limit = params[:limit]
     page = params[:page].try(:to_i) || 1
-    filters = params.slice(:uf, :city_id, :scope, :cause)
+    filters = params.slice(:uf, :city_id, :scope, :include_causes)
 
     @paginated_plips ||= plip_repository.all_initiated(filters: filters, page: page, limit: limit)
   end

--- a/app/controllers/api/v2/plips_controller.rb
+++ b/app/controllers/api/v2/plips_controller.rb
@@ -53,6 +53,13 @@ class Api::V2::PlipsController < Api::V2::ApplicationController
         key :default, :all
       end
 
+      parameter do
+        key :name, :cause
+        key :in, :query
+        key :description, "Returns national causes"
+        key :type, :boolean
+      end
+
       response 200 do
         extend Api::V2::SwaggerResponses::PaginatedHeaders
 
@@ -81,7 +88,7 @@ class Api::V2::PlipsController < Api::V2::ApplicationController
   def paginated_plips
     limit = params[:limit]
     page = params[:page].try(:to_i) || 1
-    filters = params.slice(:uf, :city_id, :scope)
+    filters = params.slice(:uf, :city_id, :scope, :cause)
 
     @paginated_plips ||= plip_repository.all_initiated(filters: filters, page: page, limit: limit)
   end

--- a/app/helpers/user_input.rb
+++ b/app/helpers/user_input.rb
@@ -1,0 +1,9 @@
+module UserInput
+  def bool(value)
+    case value
+    when true, /\Atrue\z/i then true
+    else
+      false
+    end
+  end
+end

--- a/app/repositories/plip_repository.rb
+++ b/app/repositories/plip_repository.rb
@@ -9,13 +9,15 @@ class PlipRepository
 
   def all_initiated(filters: {}, page: 1, limit: 10)
     default_filters = {
-      cause: false,
+      include_causes: false,
     }
     filters = (filters || {}).reverse_merge(default_filters)
-    cause = bool(filters[:cause])
+    causes_only = filters[:scope] === "causes"
+    include_causes = bool(filters[:include_causes]) || causes_only
     uf = filters[:uf]
+    uf = nil if include_causes
     city_id = filters[:city_id]
-    city_id = nil if cause
+    city_id = nil if include_causes
 
     # Backwards compatibility
     is_nationwide_search = uf.blank? && city_id.blank? && filters[:scope].blank?
@@ -35,7 +37,6 @@ class PlipRepository
       .where.not(petition_plugin_detail_versions: { id: nil })
       .where(petition_plugin_detail_versions: { published: true })
 
-
     scope = if is_nationwide_search
               PetitionPlugin::Detail::NATIONWIDE_SCOPE
             elsif PetitionPlugin::Detail::SCOPE_COVERAGES.include?(filters[:scope])
@@ -45,23 +46,40 @@ class PlipRepository
     filtered_phases = filtered_phases.where(petition_plugin_details: { uf: uf }) if uf.present?
     filtered_phases = filtered_phases.where(petition_plugin_details: { city_id: city_id }) if city_id.present?
 
-    if !scope && !cause
+    if causes_only
       statements = Hash[*PetitionPlugin::Detail::SCOPE_COVERAGES.map { |coverage| [coverage, coverage] }.flatten].symbolize_keys
       filtered_phases = filtered_phases.where(<<-SQL, statements)
+        (
+          petition_plugin_details.scope_coverage = :statewide
+          AND coalesce(petition_plugin_details.uf, '') = ''
+        )
+        OR (
+          petition_plugin_details.scope_coverage = :citywide
+          AND petition_plugin_details.city_id IS NULL
+        )
+      SQL
+    elsif !include_causes && !scope
+      statements = Hash[*PetitionPlugin::Detail::SCOPE_COVERAGES.map { |coverage| [coverage, coverage] }.flatten].symbolize_keys
+
+      filtered_phases = filtered_phases.where(<<-SQL, statements)
         petition_plugin_details.scope_coverage = :nationwide
-        OR petition_plugin_details.scope_coverage = :statewide
+        OR (
+          petition_plugin_details.scope_coverage = :statewide
+          AND coalesce(petition_plugin_details.uf, '') <> ''
+        )
         OR (petition_plugin_details.scope_coverage = :citywide AND petition_plugin_details.city_id IS NOT NULL)
       SQL
-    end
-
-    filtered_phases = filtered_phases.where(petition_plugin_details: { scope_coverage: scope }) if scope
-
-    if scope === PetitionPlugin::Detail::CITYWIDE_SCOPE
-      if !cause
-        filtered_phases = filtered_phases.where.not(petition_plugin_details: { city_id: nil })
-      else
-        filtered_phases = filtered_phases.where(petition_plugin_details: { city_id: nil })
-      end
+    elsif !include_causes && scope != PetitionPlugin::Detail::NATIONWIDE_SCOPE
+      statements = { scope_coverage: scope }
+      filtered_phases = filtered_phases.where(<<-SQL, statements)
+        petition_plugin_details.scope_coverage = :scope_coverage
+        AND (
+          coalesce(petition_plugin_details.uf, '') <> ''
+          OR petition_plugin_details.city_id IS NOT NULL
+        )
+      SQL
+    elsif scope
+      filtered_phases = filtered_phases.where(petition_plugin_details: { scope_coverage: scope })
     end
 
     phases =

--- a/app/repositories/plip_repository.rb
+++ b/app/repositories/plip_repository.rb
@@ -1,5 +1,6 @@
 class PlipRepository
   include Repository
+  include UserInput
 
   def current_plip
     plips = all_initiated(page: 1, limit: 1).items
@@ -7,9 +8,15 @@ class PlipRepository
   end
 
   def all_initiated(filters: {}, page: 1, limit: 10)
-    filters = filters || {}
+    default_filters = {
+      cause: false,
+    }
+    filters = (filters || {}).reverse_merge(default_filters)
+    cause = bool(filters[:cause])
     uf = filters[:uf]
     city_id = filters[:city_id]
+    city_id = nil if cause
+
     # Backwards compatibility
     is_nationwide_search = uf.blank? && city_id.blank? && filters[:scope].blank?
     limit = (limit || 10).to_i
@@ -28,8 +35,6 @@ class PlipRepository
       .where.not(petition_plugin_detail_versions: { id: nil })
       .where(petition_plugin_detail_versions: { published: true })
 
-    filtered_phases = filtered_phases.where(petition_plugin_details: { uf: uf }) if uf.present?
-    filtered_phases = filtered_phases.where(petition_plugin_details: { city_id: city_id }) if city_id.present?
 
     scope = if is_nationwide_search
               PetitionPlugin::Detail::NATIONWIDE_SCOPE
@@ -37,10 +42,32 @@ class PlipRepository
               filters[:scope]
             end
 
+    filtered_phases = filtered_phases.where(petition_plugin_details: { uf: uf }) if uf.present?
+    filtered_phases = filtered_phases.where(petition_plugin_details: { city_id: city_id }) if city_id.present?
+
+    if !scope && !cause
+      statements = Hash[*PetitionPlugin::Detail::SCOPE_COVERAGES.map { |coverage| [coverage, coverage] }.flatten].symbolize_keys
+      filtered_phases = filtered_phases.where(<<-SQL, statements)
+        petition_plugin_details.scope_coverage = :nationwide
+        OR petition_plugin_details.scope_coverage = :statewide
+        OR (petition_plugin_details.scope_coverage = :citywide AND petition_plugin_details.city_id IS NOT NULL)
+      SQL
+    end
+
     filtered_phases = filtered_phases.where(petition_plugin_details: { scope_coverage: scope }) if scope
+
+    if scope === PetitionPlugin::Detail::CITYWIDE_SCOPE
+      if !cause
+        filtered_phases = filtered_phases.where.not(petition_plugin_details: { city_id: nil })
+      else
+        filtered_phases = filtered_phases.where(petition_plugin_details: { city_id: nil })
+      end
+    end
 
     phases =
       Phase.where(id: filtered_phases.pluck(:id))
+        .includes(:cycle)
+        .includes(plugin_relation: { petition_detail: %i(petition_detail_versions city) })
         .order("initial_date DESC")
         .page(page)
         .per(limit)


### PR DESCRIPTION
This PR closes #400.

### What has changed?

- now the plips api receives a `**include_causes**:boolean` which instruct it to return national causes
- by default it won't return
- the scope filter now can receive `causes` which will only return national causes
- `scope=all&include_causes=true` returns everything including national causes
- `scope=citywide&include_causes=true` returns only citywide including national causes
- `scope=citywide&cause=false` returns only citywide plips

### Is this PR dangerous?

No, it's backwards compatible.