### PR TITLE
Hide pdf signature list link when national cause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR 412]: Hide pdf signature list link when national cause
 * [PR 409]: Handle national cause goals (Issue 408)
 * [PR 406]: Allow national cause creation (statewide) (Issue 403, 405)
 * [PR 402]: Return national causes on the plips api (Issue 400)

--- a/app/assets/stylesheets/petition/index.css.sass
+++ b/app/assets/stylesheets/petition/index.css.sass
@@ -227,6 +227,9 @@
       padding: 16px 0
       text-align: center
 
+      &.national-cause
+        background-color: transparent
+
       a
         color: #fff !important
 

--- a/app/views/cycles/plugin_relations/petition.html.slim
+++ b/app/views/cycles/plugin_relations/petition.html.slim
@@ -86,9 +86,10 @@ section#petition-index
               small assinaturas
 
         .row#petition-signers-desktop.signatures-list.visible-lg-block
-        .row.view-all-signatures
+        .row.view-all-signatures class="#{@petition.national_cause? ? "national-cause" : ""}"
           .container-fluid
-            a href="#{petition_signatures_path(@petition)}" style="color: #{@cycle.color}" Confira as assinaturas autenticadas
+            - unless @petition.national_cause?
+              a href="#{petition_signatures_path(@petition)}" style="color: #{@cycle.color}" Confira as assinaturas autenticadas
 
         - if @phase.in_progress?
           - if @user_signed_petition


### PR DESCRIPTION
This PR closes #411.

### What has changed?

- The pdf signature list link is not displayed when a national cause.