### PR TITLE
Return empty pdf signature list if national cause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR 416]: Return empty pdf signature list if national cause
 * [PR 414]: Add a high limit for now when listing plips
 * [PR 412]: Hide pdf signature list link when national cause
 * [PR 409]: Handle national cause goals (Issue 408)

--- a/app/services/petition_service.rb
+++ b/app/services/petition_service.rb
@@ -71,6 +71,10 @@ class PetitionService
     cache_key = "mobile_petition_signatures:#{petition_id}"
 
     Rails.cache.fetch(cache_key, force: fresh) do
+      petition = petition_repository.find_by_id!(petition_id)
+      # For now national cause won't list the pdf signatures
+      return [] if petition.national_cause?
+
       mobile_service.petition_signatures(petition_id)
     end
   end


### PR DESCRIPTION
This PR closes #415.

### What has changed?

- now the pdf signatures list will be empty when national cause instead of calling the blockchain api