### PR TITLE
Add new signature goal calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR 424]: Add new signature goal calculation
 * [PR 420]: Bump gems with known CVEs
 
 ## [1.22.0] - 24/11/2017

--- a/app/models/petition_plugin/detail.rb
+++ b/app/models/petition_plugin/detail.rb
@@ -32,7 +32,7 @@ class PetitionPlugin::Detail < ActiveRecord::Base
   validates :call_to_action, presence: true
   validates :signatures_required, presence: true, numericality: { greater_than_or_equal_to: :initial_signatures_goal }
   validates :initial_signatures_goal, presence: true
-  validates :signatures_required, :initial_signatures_goal, numericality: { greater_than_or_equal_to: 1_000 }
+  validates :signatures_required, :initial_signatures_goal, numericality: { greater_than_or_equal_to: 1 }
   validates :presentation, presence: true
   validates :scope_coverage, presence: true, inclusion: { in: SCOPE_COVERAGES }
   validates :uf, inclusion: { in: UFS, allow_blank: true }, if: -> { scope_coverage == STATEWIDE_SCOPE }


### PR DESCRIPTION
This PR closes #423 

### What has changed?

- it's possible now to create plips with initial signature goals less than 1000. (min 1)
- for plips with initial signature goal less than 1000 a new current goal algorithm takes place
  - double the target until the current signature is past
 
eg.

```
signatures = 0
initial = 15
goal_result = 15
```

```
signatures = 023
initial = 15
goal_result = 30
```

```
signatures = 58
initial = 15
goal_result = 60
```