### PR TITLE
Improve app cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR 435]: Improve app cache
 * [PR 433]: Add puma web server
   - Set env `RAILS_MAX_THREADS` to `16`
   - Set env `RAILS_MIN_THREADS` to `5`

--- a/Gemfile
+++ b/Gemfile
@@ -94,6 +94,8 @@ gem 'browser'
 
 gem "one_signal" # Mobile push message service
 
+gem "actionpack-action_caching"
+
 group :development, :test, :staging do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   #gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,8 @@ GEM
       rack-test (~> 0.6.2)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    actionpack-action_caching (1.2.0)
+      actionpack (>= 4.0.0, < 6)
     actionview (4.2.10)
       activesupport (= 4.2.10)
       builder (~> 3.1)
@@ -620,6 +622,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  actionpack-action_caching
   acts-as-taggable-on
   annotate
   attr_encrypted

--- a/app/controllers/api/v2/petitions_controller.rb
+++ b/app/controllers/api/v2/petitions_controller.rb
@@ -56,7 +56,7 @@ class Api::V2::PetitionsController < Api::V2::ApplicationController
       end
     end
   end
- 
+
   swagger_path "/petitions/{sha}/status" do
     operation :get do
       extend Api::V2::SwaggerResponses::InternalError
@@ -108,7 +108,7 @@ class Api::V2::PetitionsController < Api::V2::ApplicationController
     render json: { status: petition_status }
     expires_in expires_time.minutes, public: true
   rescue MobileApiService::ValidationError => e
-    render json: e.validations, status: 422 
+    render json: e.validations, status: 422
   end
 
   private

--- a/app/controllers/cycles/plugin_relations_controller.rb
+++ b/app/controllers/cycles/plugin_relations_controller.rb
@@ -4,6 +4,8 @@ class Cycles::PluginRelationsController < ApplicationController
     action_name == "show" && plugin_relation.plugin.plugin_type == "Petição"
   end
 
+  caches_action :show, expires_in: 5.minutes
+
   attr_writer :presignature_repository
   attr_accessor :petition_service
 

--- a/app/controllers/cycles_controller.rb
+++ b/app/controllers/cycles_controller.rb
@@ -1,6 +1,8 @@
 class CyclesController < ApplicationController
   before_action :home_blocks, only: %i(index)
 
+  caches_action :show, expires_in: 10.minutes
+
   def home_block_repository
     @home_block_repository ||= HomeBlockRepository.new
   end

--- a/app/controllers/embedded/petitions_controller.rb
+++ b/app/controllers/embedded/petitions_controller.rb
@@ -1,7 +1,6 @@
 class Embedded::PetitionsController < Embedded::ApplicationController
   caches_action :show, expires_in: 5.minutes, cache_path: -> do
-    keys = %w(flags)
-    params.select { |k| keys.include? k }
+    params.slice(:flags)
   end
 
   attr_reader :petition_detail_repository

--- a/app/controllers/embedded/petitions_controller.rb
+++ b/app/controllers/embedded/petitions_controller.rb
@@ -1,5 +1,8 @@
 class Embedded::PetitionsController < Embedded::ApplicationController
-  before_action :set_petition, only: [:show]
+  caches_action :show, expires_in: 5.minutes, cache_path: -> do
+    keys = %w(flags)
+    params.select { |k| keys.include? k }
+  end
 
   attr_reader :petition_detail_repository
 
@@ -20,7 +23,7 @@ class Embedded::PetitionsController < Embedded::ApplicationController
 
   helper_method :petition
   def petition
-    @petition
+    @petition ||= petition_detail_repository.find_by_id!(params[:id])
   end
 
   helper_method :phase
@@ -31,11 +34,5 @@ class Embedded::PetitionsController < Embedded::ApplicationController
   helper_method :cycle
   def cycle
     phase.cycle
-  end
-
-  private
-
-  def set_petition
-    @petition = petition_detail_repository.find_by_id!(params[:id])
   end
 end

--- a/app/controllers/petitions_controller.rb
+++ b/app/controllers/petitions_controller.rb
@@ -1,11 +1,13 @@
 class PetitionsController < ApplicationController
   before_action :set_page_title, only: %i(verify)
-  before_action :petition, :cycle, only: %i(signatures)
+  caches_action :signatures, expires_in: 10.minutes
+  caches_action :verify, expires_in: 3.hours
 
   def verify
   end
 
   def signatures
+    cycle
     @signatures = petition_service.fetch_petition_signatures(params[:petition_id])
   end
 
@@ -31,7 +33,7 @@ class PetitionsController < ApplicationController
   end
 
   def cycle
-    @cycle ||= @petition.plugin_relation.cycle
+    @cycle ||= petition.plugin_relation.cycle
   end
 
   def petition_service

--- a/app/controllers/plips_controller.rb
+++ b/app/controllers/plips_controller.rb
@@ -2,8 +2,7 @@ class PlipsController < ApplicationController
   layout "static"
 
   caches_action :index, expires_in: 10.minutes, cache_path: -> do
-    keys = %w(scope_coverage)
-    params.select { |k| keys.include? k }
+    params.slice(:scope_coverage)
   end
 
   def index

--- a/app/controllers/plips_controller.rb
+++ b/app/controllers/plips_controller.rb
@@ -1,6 +1,11 @@
 class PlipsController < ApplicationController
   layout "static"
 
+  caches_action :index, expires_in: 10.minutes, cache_path: -> do
+    keys = %w(scope_coverage)
+    params.select { |k| keys.include? k }
+  end
+
   def index
     plip_repository = PlipRepository.new
     @plips = plip_repository.all_initiated(filters: filters, limit: 100)

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,6 +1,9 @@
 class StaticController < ApplicationController
   layout "static"
 
+  caches_action :index, expires_in: 30.minutes
+  caches_action :about, expires_in: 1.hour
+
   def about
   end
 

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,4 +1,6 @@
 class StaticPagesController < ApplicationController
+  caches_action :show, expires_in: 10.minutes
+
   def show
     @static_page = StaticPage.find params[:id]
   end

--- a/app/models/plip.rb
+++ b/app/models/plip.rb
@@ -53,4 +53,13 @@ class Plip
   def petition_info
     @petition_info ||= petition_service.fetch_petition_info_with(petition: detail)
   end
+
+  def marshal_dump
+    [detail, phase, plip_url]
+  end
+
+  def marshal_load(args)
+    attrs = %w(detail phase plip_url).zip args
+    initialize(**Hash[attrs].deep_symbolize_keys)
+  end
 end

--- a/app/services/petition_service.rb
+++ b/app/services/petition_service.rb
@@ -54,7 +54,7 @@ class PetitionService
       petition = petition_repository.find_by_id!(petition_id)
 
       if petition.published_version.present?
-        return mobile_service.petition_version_signers petition.published_version.id, limit
+        mobile_service.petition_version_signers petition.published_version.id, limit
       end
     end
   end
@@ -73,9 +73,11 @@ class PetitionService
     Rails.cache.fetch(cache_key, force: fresh) do
       petition = petition_repository.find_by_id!(petition_id)
       # For now national cause won't list the pdf signatures
-      return [] if petition.national_cause?
-
-      mobile_service.petition_signatures(petition_id)
+      if petition.national_cause?
+        Array.new
+      else
+        mobile_service.petition_signatures(petition_id)
+      end
     end
   end
 

--- a/app/views/embedded/petitions/show.html.slim
+++ b/app/views/embedded/petitions/show.html.slim
@@ -55,7 +55,7 @@ javascript:
     var isNationalCause = #{petition.national_cause?};
 
     if ($(".petition-container").is(".has_signers")) {
-      $(".signers").muPetitionSignersSmall(#{@petition.id}, petitionInProgress, apiClient, { size: 9 });
+      $(".signers").muPetitionSignersSmall(#{petition.id}, petitionInProgress, apiClient, { size: 9 });
     }
 
     function updateSignaturesCount() {


### PR DESCRIPTION
This PR closes #434 

### What has changed?

- fixed plip (petition service) cache which was not properly using it. The was an early return which obviously would return from the cache block without writing to it
- plip page now has a cache of 5 minutes
- cycle page now has a cache of 10 minutes
- embedded plip now has a cache of 5 minutes
- project (plips) page now has a cache of 10 minutes
- plip signatures page now has a cache of 10 minutes
- signature verification page has a cache of 3 hours
- home page now has a cache of 30 minutes
- static pages  has a cache of 10 minutes
- about page has a cache of 1 hour
- plips api now has a cache configurable through `API_EXPIRES_IN` (minutes) env var

I guess some expiration times can be tuned further, but we need metrics on cache hit first.

### Is this PR dangerous?

Mainly because of the plips api cache. This means that we won't be real time with modifications.