### PR TITLE
Add API call to get one plip by slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-* [PR 446]: Add API call to get one plip by slug
+* [PR 447]: Add API call to get one plip by slug
 
 ## [1.27.0] - 12/04/2018
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* [PR 446]: Add API call to get one plip by slug
+
 ## [1.27.0] - 12/04/2018
 
 * [PR 445]: Upgrade ruby to 2.5.1

--- a/app/controllers/api/v2/plips_controller.rb
+++ b/app/controllers/api/v2/plips_controller.rb
@@ -124,10 +124,10 @@ class Api::V2::PlipsController < Api::V2::ApplicationController
     render json: plips_pagination[:response]
   end
 
-  def find_by_slug
+  def show
     ttl = Rails.application.secrets.http_cache["api_expires_in"].minutes
 
-    slug = params[:slug]
+    slug = params[:id]
     plip = plip_repository.find_plip_by_slug(slug)
 
     render json: success_response(Api::V2::Entities::Plip.represent(plip))

--- a/app/repositories/plip_repository.rb
+++ b/app/repositories/plip_repository.rb
@@ -7,6 +7,15 @@ class PlipRepository
     plips.last
   end
 
+  def find_plip_by_slug(slug)
+    phase = Cycle.find_by_slug(slug).phases.last
+    petition = phase.plugin_relation.petition_detail
+
+    Plip.new detail: petition,
+             phase: phase,
+             plip_url: generate_plip_url(phase)
+  end
+
   def all_initiated(filters: {}, page: 1, limit: 10)
     default_filters = {
       include_causes: false,

--- a/app/repositories/plip_repository.rb
+++ b/app/repositories/plip_repository.rb
@@ -8,7 +8,16 @@ class PlipRepository
   end
 
   def find_plip_by_slug(slug)
-    phase = Cycle.find_by_slug(slug).phases.last
+    phase = Phase
+        .includes(:cycle)
+        .where(cycle: Cycle.find(slug))
+        .includes(:plugin_relation)
+        .joins(plugin_relation: :plugin)
+        .includes(plugin_relation: :petition_detail)
+        .includes(plugin_relation: { petition_detail: %i(petition_detail_versions city) })
+        .where(plugin_relation: { plugin: { plugin_type: PluginTypeRepository::ALL_TYPES[:petition] }})
+        .first
+
     petition = phase.plugin_relation.petition_detail
 
     Plip.new detail: petition,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,6 @@ include BaseRouting::RoutingMethods
 
 Rails.application.routes.draw do
   get 'plips' => 'plips#index', path: 'projetos'
-  get 'plips/:id_or_slug' => 'plips#find', path: 'projetos'
 
   use_doorkeeper
   devise_for :admin_users, controllers: {
@@ -112,7 +111,7 @@ Rails.application.routes.draw do
     namespace :v2 do
       resources :apidocs, only: %i(index)
       resources :plips, only: %i(index)
-      match '/plips/:slug', to: 'plips#find_by_slug', via: :get
+      get "/plips/:slug" => "plips#find_by_slug"
       resources :petitions, only: [] do
         get :info
         get :signers

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -110,8 +110,7 @@ Rails.application.routes.draw do
 
     namespace :v2 do
       resources :apidocs, only: %i(index)
-      resources :plips, only: %i(index)
-      get "/plips/:slug" => "plips#find_by_slug"
+      resources :plips, only: %i(index show)
       resources :petitions, only: [] do
         get :info
         get :signers

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ include BaseRouting::RoutingMethods
 
 Rails.application.routes.draw do
   get 'plips' => 'plips#index', path: 'projetos'
+  get 'plips/:id_or_slug' => 'plips#find', path: 'projetos'
 
   use_doorkeeper
   devise_for :admin_users, controllers: {
@@ -111,6 +112,7 @@ Rails.application.routes.draw do
     namespace :v2 do
       resources :apidocs, only: %i(index)
       resources :plips, only: %i(index)
+      match '/plips/:slug', to: 'plips#find_by_slug', via: :get
       resources :petitions, only: [] do
         get :info
         get :signers


### PR DESCRIPTION
This PR closes #446.

### How was it before?

- API hadn't a function to return just one plip.

### What has changed?

- Add new GET route to return that one.

### What should I pay attention when reviewing this PR?

Nothing in particular.

### Is this PR dangerous?

No.
