### PR TITLE
Temporarily remove links to mobilize page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR 459]: Temporarily remove links to mobilize page
 * [PR 455]: Add mobilize static page
 * [PR 457]: Docker file with app config
   - Set env `MEMCACHE_SERVERS`

--- a/app/views/plips/index.html.slim
+++ b/app/views/plips/index.html.slim
@@ -7,7 +7,7 @@ header.header.clearfix
     span
       a.link.def-text-color.underscore#btn-home href="/" Home
     span
-      a.link.def-text-color.underscore#btn-mobilizacao href="/mobilizacao" Guia de mobilização
+      /! a.link.def-text-color.underscore#btn-mobilizacao href="/mobilizacao" Guia de mobilização
     span
       a.link.def-text-color.underscore#btn-quemsomos href="/quem-somos" Quem somos
     span

--- a/app/views/static/about.html.slim
+++ b/app/views/static/about.html.slim
@@ -2,7 +2,7 @@ header.header.clearfix#desktop
   nav.links
     a.link.def-text-color.underscore href="/" Home
     a.link.def-text-color.underscore href="/projetos" Assine um projeto
-    a.link.def-text-color.underscore href="/mobilizacao" Guia de mobilização
+    /! a.link.def-text-color.underscore href="/mobilizacao" Guia de mobilização
     a.link.def-text-color.underscore href="https://itsrio2.typeform.com/to/iulNZI" target="_blank" Envie seu projeto
 
   .logos.small
@@ -18,7 +18,7 @@ article.about-us.gradient-section
     span.link-mobile
       a.link.def-text-color.menu-underscore href="/projetos" Assine um projeto
     span.link-mobile
-      a.link.def-text-color.menu-underscore href="/mobilizacao" Guia de mobilização
+      /! a.link.def-text-color.menu-underscore href="/mobilizacao" Guia de mobilização
     span.link-mobile
       a.link.def-text-color.menu-underscore href="https://itsrio2.typeform.com/to/iulNZI" target="_blank" Envie seu projeto
   .logos.small#mobile.mobile-img

--- a/app/views/static/index.html.slim
+++ b/app/views/static/index.html.slim
@@ -1,7 +1,7 @@
 header.header.clearfix#desktop
   nav.links
     a.link.def-text-color.underscore href="/projetos" Assine um projeto
-    a.link.def-text-color.underscore href="/mobilizacao" Guia de mobilização
+    /! a.link.def-text-color.underscore href="/mobilizacao" Guia de mobilização
     a.link.def-text-color.underscore href="/quem-somos" Quem somos
     a.link.def-text-color.underscore href="https://itsrio2.typeform.com/to/iulNZI" target="_blank" Envie seu projeto
   .logos.great
@@ -12,7 +12,7 @@ article.homepage.gradient-section
     span.link-mobile
       a.link.def-text-color.menu-underscore href="/projetos" Assine um projeto
     span.link-mobile
-      a.link.def-text-color.menu-underscore href="/mobilizacao" Guia de mobilização
+      /! a.link.def-text-color.menu-underscore href="/mobilizacao" Guia de mobilização
     span.link-mobile
       a.link.def-text-color.menu-underscore href="/quem-somos" Quem somos
     span.link-mobile

--- a/app/views/static/mobilize.html.slim
+++ b/app/views/static/mobilize.html.slim
@@ -61,7 +61,7 @@ article.mobilize.gradient-section
         .icon.mobile-img
           = image_tag "static/adesivos-e-bottons-icon.svg"
         .content
-          h2.title Adesivos, Bottons e Logos Mudamos
+          h2.title Adesivos e Bottons Mudamos
           p.text.def-text-color
             | Tem coisa mais legal do que levar alguns adesivos e bottons do Mudamos na bolsa e apresentar o aplicativo para qualquer pessoa, em qualquer lugar? Ela lembra de baixar e ainda fica com uma recordação.
           a.title.download href="https://s3-sa-east-1.amazonaws.com/mudamos-images/images/mobilizacao/Adesivos+e+Bottons.zip" baixe os modelos aqui


### PR DESCRIPTION
This PR closes #458.

### How was it before?

- Users can navigate to mobilize page.

### What has changed?

- Temporarily mobilize page can only be accessed by url.

### What should I pay attention when reviewing this PR?

Nothing in particular.

### Is this PR dangerous?

No.
