### PR TITLE
Bug fix at plip info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* [PR 462]: Bug fix at plip info
+
 ## [1.28.0] - 25/05/2018
 
 * [PR 459]: Temporarily remove links to mobilize page

--- a/app/services/petition_service.rb
+++ b/app/services/petition_service.rb
@@ -125,9 +125,9 @@ class PetitionService
     #     end
     #   end
     low_method = -> {
-      target = initial_signatures_goal * (2 ** (Math.log(signatures_count / initial_signatures_goal.to_f) / Math.log(2)).ceil).to_f
+      target = initial_signatures_goal * (2 ** (Math.log(signatures_count / initial_signatures_goal.to_f) / Math.log(2)).ceil)
       target = target * 2 if target == signatures_count
-      clamp.call target.zero? ? initial_signatures_goal : target
+      clamp.call target.zero? ? initial_signatures_goal : target.ceil
     }
 
     high_method = -> {

--- a/app/services/petition_service.rb
+++ b/app/services/petition_service.rb
@@ -125,7 +125,7 @@ class PetitionService
     #     end
     #   end
     low_method = -> {
-      target = initial_signatures_goal * (2 ** (Math.log(signatures_count / initial_signatures_goal.to_f) / Math.log(2)).ceil)
+      target = initial_signatures_goal * (2 ** (Math.log(signatures_count / initial_signatures_goal.to_f) / Math.log(2)).ceil).to_f
       target = target * 2 if target == signatures_count
       clamp.call target.zero? ? initial_signatures_goal : target
     }


### PR DESCRIPTION
This PR closes #461.

### How was it before?

- When open a plip page with current goal less than 1000, the "current signature goal" had value 0.

### What has changed?

- "current signature goal" receives the correct value.

### What should I pay attention when reviewing this PR?

Nothing in particular.

### Is this PR dangerous?

No.
