### PR TITLE
Fix share link when unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR 465]: Fix share link when unavailable
 * [PR 462]: Bug fix at plip info
 
 ## [1.28.0] - 25/05/2018

--- a/app/services/share_link_metrics_service.rb
+++ b/app/services/share_link_metrics_service.rb
@@ -27,6 +27,7 @@ class ShareLinkMetricsService
   end
 
   def get_metrics(share_link, days)
+    return if share_link.blank?
     share_link_addressable = CGI.escape(share_link)
     response = get("https://firebasedynamiclinks.googleapis.com/v1/#{share_link_addressable}/linkStats?durationDays=#{days}")
     if response

--- a/app/use_cases/petition_plugin/detail_updater.rb
+++ b/app/use_cases/petition_plugin/detail_updater.rb
@@ -1,8 +1,8 @@
 module PetitionPlugin
 
-  Response = Struct.new(:success, :detail, :version)
-
   class DetailUpdater
+    Response = Struct.new(:success, :detail, :version)
+
     def perform(detail, attrs, detail_body)
       response = Response.new
 

--- a/app/use_cases/petition_plugin/dynamic_link_metrics.rb
+++ b/app/use_cases/petition_plugin/dynamic_link_metrics.rb
@@ -1,8 +1,8 @@
 module PetitionPlugin
 
-  Response = Struct.new(:android, :ios, :other)
-
   class DynamicLinkMetrics
+    Response = Struct.new(:android, :ios, :other)
+
     attr_accessor :share_link_metrics_service
 
     def initialize(share_link_metrics_service: ShareLinkMetricsService.new)


### PR DESCRIPTION
This PR closes #464 

### What has changed?

- fixed fetching share link when unavailable
- fixed constant namespace definition