### PR TITLE
Add links to mobilize page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* [PR 469]: Add links to mobilize page
+
 ## [1.28.1] - 06/06/2018
 
 * [PR 465]: Fix share link when unavailable

--- a/app/assets/stylesheets/static/mobilize.scss
+++ b/app/assets/stylesheets/static/mobilize.scss
@@ -66,6 +66,13 @@
       order: 2;
     }
 
+    .video {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin-top: 70px;
+    }
+
     .mobilize-logo img {
       max-width: 375px;
       width: 33vw;

--- a/app/views/plips/index.html.slim
+++ b/app/views/plips/index.html.slim
@@ -7,7 +7,7 @@ header.header.clearfix
     span
       a.link.def-text-color.underscore#btn-home href="/" Home
     span
-      /! a.link.def-text-color.underscore#btn-mobilizacao href="/mobilizacao" Guia de mobilização
+      a.link.def-text-color.underscore#btn-mobilizacao href="/mobilizacao" Guia de mobilização
     span
       a.link.def-text-color.underscore#btn-quemsomos href="/quem-somos" Quem somos
     span

--- a/app/views/static/about.html.slim
+++ b/app/views/static/about.html.slim
@@ -2,7 +2,7 @@ header.header.clearfix#desktop
   nav.links
     a.link.def-text-color.underscore href="/" Home
     a.link.def-text-color.underscore href="/projetos" Assine um projeto
-    /! a.link.def-text-color.underscore href="/mobilizacao" Guia de mobilização
+    a.link.def-text-color.underscore href="/mobilizacao" Guia de mobilização
     a.link.def-text-color.underscore href="https://itsrio2.typeform.com/to/iulNZI" target="_blank" Envie seu projeto
 
   .logos.small
@@ -18,7 +18,7 @@ article.about-us.gradient-section
     span.link-mobile
       a.link.def-text-color.menu-underscore href="/projetos" Assine um projeto
     span.link-mobile
-      /! a.link.def-text-color.menu-underscore href="/mobilizacao" Guia de mobilização
+      a.link.def-text-color.menu-underscore href="/mobilizacao" Guia de mobilização
     span.link-mobile
       a.link.def-text-color.menu-underscore href="https://itsrio2.typeform.com/to/iulNZI" target="_blank" Envie seu projeto
   .logos.small#mobile.mobile-img

--- a/app/views/static/index.html.slim
+++ b/app/views/static/index.html.slim
@@ -1,7 +1,7 @@
 header.header.clearfix#desktop
   nav.links
     a.link.def-text-color.underscore href="/projetos" Assine um projeto
-    /! a.link.def-text-color.underscore href="/mobilizacao" Guia de mobilização
+    a.link.def-text-color.underscore href="/mobilizacao" Guia de mobilização
     a.link.def-text-color.underscore href="/quem-somos" Quem somos
     a.link.def-text-color.underscore href="https://itsrio2.typeform.com/to/iulNZI" target="_blank" Envie seu projeto
   .logos.great
@@ -12,7 +12,7 @@ article.homepage.gradient-section
     span.link-mobile
       a.link.def-text-color.menu-underscore href="/projetos" Assine um projeto
     span.link-mobile
-      /! a.link.def-text-color.menu-underscore href="/mobilizacao" Guia de mobilização
+      a.link.def-text-color.menu-underscore href="/mobilizacao" Guia de mobilização
     span.link-mobile
       a.link.def-text-color.menu-underscore href="/quem-somos" Quem somos
     span.link-mobile

--- a/app/views/static/mobilize.html.slim
+++ b/app/views/static/mobilize.html.slim
@@ -32,6 +32,8 @@ article.mobilize.gradient-section
         h2.major-title Mobilização
         p.text.def-text-color
           | Mobilizar mais pessoas é fundamental para que seu projeto de lei de iniciativa popular alcance diferentes grupos e possa atingir o mínimo de assinaturas necessário. Afinal, a sua ideia precisa de apoio da população para que seja votada nas casas legislativas como uma legítima iniciativa do povo. Nesta página, você vai encontrar uma série de materiais de apoio e um Guia de Mobilização completo para te ajudar nesta missão! Vamos lá? :)
+        .video
+          iframe src="https://www.youtube.com/embed/rJj9wBKbLs8" frameborder="0" scrolling="0" width="700px" height="394px" allow="autoplay"
       h2.title.major-title.center Materiais
       .guide.section
         .icon.mobile-img


### PR DESCRIPTION
This PR closes #468  .

### How was it before?
 
- Common users can't access mobilize page without link;
- Mobilize page hadn't a video.

### What has changed?

- Add links to mobilize page;
- Add video at mobilize page.

### What should I pay attention when reviewing this PR?

- Nothing in particular

### Is this PR dangerous?

- No.
