### PR TITLE
Bug fix when create a petition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR 471]: Bug fix when create a petition
 * [PR 469]: Add links to mobilize page
 
 ## [1.28.1] - 06/06/2018

--- a/app/use_cases/petition_plugin/dynamic_link_metrics.rb
+++ b/app/use_cases/petition_plugin/dynamic_link_metrics.rb
@@ -10,6 +10,8 @@ module PetitionPlugin
     end
 
     def perform(petition)
+      return if !petition
+
       response = Response.new
 
       @metrics = share_link_metrics_service.get_metrics petition.share_link, 30


### PR DESCRIPTION
This PR closes #470  .

### How was it before?
 
- After a cycle was created, when click to create the petition details the system crash.

### What has changed?

- New validation to verify if the details of petition was created, if not the worker will just return else it will get the share link metrics.

### Details of the bug
- At today's flow, when the petition was created, it will be without his details. After that the user must add it to the petition to finish the flow. When the user open the petition details to add, edit or view the worker that get the share link metrics is called automatically passing the details as parameter. Because of that, the system pass `nil` as detais and the worker lost itself, resulting in a error and crashing that page.

### What should I pay attention when reviewing this PR?

- Nothing in particular

### Is this PR dangerous?

- No.
