### PR TITLE
Fix multiline env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [PR 475]: Fix multiline env var
 * [PR 472]: Call api to sync the updated petition
   - run `rake petitions:sync_plips`
 * [PR 467]: Sync plip worker

--- a/config/initializers/fix-env-vars.rb
+++ b/config/initializers/fix-env-vars.rb
@@ -1,0 +1,2 @@
+# Fix multiline private key when it's loaded using a json file
+ENV["GOOGLE_PRIVATE_KEY"] = ENV["GOOGLE_PRIVATE_KEY"].gsub("\\n", "\n") if ENV["GOOGLE_PRIVATE_KEY"].present?


### PR DESCRIPTION
This PR closes #474 .

### How was it before?

- Using a json file file which loads env vars would add a escape to multiline text

### What has changed?

- added a new initializer which removes this from an specific env var