### PR TITLE
Allow skipping the app landing page when the url contains a special key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* [PR 513] Allow skipping the app landing page when the url contains a special key
+
 # [1.34.0] - 25/09/2020
 
 * [PR 511] Update LAI pdf template

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -39,13 +39,13 @@ class ApplicationController < ActionController::Base
   end
 
   def app_landing_page
+    if params.key? :no_app_landing_page
+      set_app_landing_page_seen
+      return
+    end
+
     if !cookies[:has_seen_app_landing] || request.host =~ %r{app.mudamos.org}
-      cookies[:has_seen_app_landing] = {
-        value: true,
-        expires: 1.year.from_now,
-        secure: !Rails.env.development?,
-        httponly: true
-      }
+      set_app_landing_page_seen
 
       render file: Rails.public_path.join("landing.html"), layout: false
     end
@@ -58,6 +58,15 @@ class ApplicationController < ActionController::Base
   end
 
   private
+
+    def set_app_landing_page_seen
+      cookies[:has_seen_app_landing] = {
+        value: true,
+        expires: 1.year.from_now,
+        secure: !Rails.env.development?,
+        httponly: true
+      }
+    end
 
     def plugin_type_repository
       @plugin_type_repository ||= PluginTypeRepository.new


### PR DESCRIPTION
This PR closes #512 .

#### Feature

It's now possible to skip the app landing page if the url contains the query string `no_app_landing_page`