### PR TITLE
feat: Add Google analytics 4 tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Next
 
+# [1.36.0] - 06/06/2023
+
+* [PR 535] feat: Add Google analytics 4 tag
+
 # [1.35.1] - 08/12/2022
 
 * [PR 530] Redirect admin user to admin context

--- a/app/views/outsiders/_analytics.html.erb
+++ b/app/views/outsiders/_analytics.html.erb
@@ -21,3 +21,13 @@
 
   gtag('config', 'AW-846743393');
 </script>
+
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-YFCGV443XK"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-YFCGV443XK');
+</script>

--- a/public/landing.html
+++ b/public/landing.html
@@ -159,5 +159,15 @@
 
       gtag('config', 'AW-846743393');
     </script>
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-YFCGV443XK"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-YFCGV443XK');
+    </script>
   </body>
 </html>


### PR DESCRIPTION
Closes #534 

This PR adds the new Google analytics 4 tracking id. Mainly used to track pageviews